### PR TITLE
Theme Context Hook

### DIFF
--- a/.changeset/hip-glasses-buy.md
+++ b/.changeset/hip-glasses-buy.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': patch
+---
+
+Added and exported useThemeContext

--- a/packages/components/src/components/Footer.tsx
+++ b/packages/components/src/components/Footer.tsx
@@ -9,7 +9,7 @@ import {
   Wrapper,
 } from './Footer.styles';
 
-import { ThemeContext } from '../helpers/theme';
+import { useThemeContext } from '../helpers/theme';
 import { logoThemedIcons } from '../helpers/assets';
 import { IFooterProps } from '../types/components';
 
@@ -45,7 +45,7 @@ const links = [
 ];
 
 export const Footer: React.FC<IFooterProps> = ({ sameSite, ...restProps }) => {
-  const { isDarkTheme } = React.useContext(ThemeContext);
+  const { isDarkTheme } = useThemeContext();
   const logos = logoThemedIcons(isDarkTheme || false);
 
   const logoOptions = sameSite

--- a/packages/components/src/components/FooterExtended.tsx
+++ b/packages/components/src/components/FooterExtended.tsx
@@ -14,7 +14,7 @@ import {
   Wrapper,
 } from './FooterExtended.styles';
 
-import { ThemeContext } from '../helpers/theme';
+import { useThemeContext } from '../helpers/theme';
 import { logoThemedIcons } from '../helpers/assets';
 import { IFooterExtendedProps, ILink } from '../types/components';
 
@@ -190,7 +190,7 @@ export const FooterExtended: React.FC<IFooterExtendedProps> = ({
   onNewsletterSubmit,
   ...restProps
 }) => {
-  const { isDarkTheme } = React.useContext(ThemeContext);
+  const { isDarkTheme } = useThemeContext();
   const logos = logoThemedIcons(isDarkTheme || false);
 
   const logoOptions = sameSite

--- a/packages/components/src/components/Header.tsx
+++ b/packages/components/src/components/Header.tsx
@@ -15,7 +15,7 @@ import {
 } from './Header.styles';
 
 import { IHeaderProps } from '../types/components';
-import { ThemeContext } from '../helpers/theme';
+import { useThemeContext } from '../helpers/theme';
 import { headerThemedIcons, logoThemedIcons } from '../helpers/assets';
 import { toggleLockBodyScroll } from '../helpers/modals';
 
@@ -26,7 +26,7 @@ export const Header: React.FC<IHeaderProps> = ({
   themeSwitch,
   ...restProps
 }) => {
-  const { isDarkTheme, setDarkTheme } = React.useContext(ThemeContext);
+  const { isDarkTheme, setDarkTheme } = useThemeContext();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const icons = headerThemedIcons(isDarkTheme || false);

--- a/packages/components/src/components/HeaderModal.tsx
+++ b/packages/components/src/components/HeaderModal.tsx
@@ -11,7 +11,7 @@ import {
 
 import { IHeaderModalProps } from '../types/components';
 import { logoThemedIcons } from '../helpers/assets';
-import { ThemeContext } from '../helpers/theme';
+import { useThemeContext } from '../helpers/theme';
 
 export const HeaderModal: React.FC<IHeaderModalProps> = ({
   title,
@@ -19,7 +19,7 @@ export const HeaderModal: React.FC<IHeaderModalProps> = ({
   onCancelModal,
   ...restProps
 }) => {
-  const { isDarkTheme } = React.useContext(ThemeContext);
+  const { isDarkTheme } = useThemeContext();
   const logoIcons = logoThemedIcons(isDarkTheme || false);
 
   const productCategories = [

--- a/packages/components/src/components/MarketplaceList.tsx
+++ b/packages/components/src/components/MarketplaceList.tsx
@@ -24,7 +24,7 @@ import {
   IMarketplaceItemsProps,
   IMarketplaceItemProps,
 } from '../types/components';
-import { ThemeContext } from '../helpers/theme';
+import { useThemeContext } from '../helpers/theme';
 import { marketplaceThemedAssets } from '../helpers/assets';
 import { toggleLockBodyScroll } from '../helpers/modals';
 
@@ -107,7 +107,7 @@ export const MarketplaceList: React.FC<IMarketplaceListProps> = ({
   pagination,
   ...restProps
 }) => {
-  const { isDarkTheme } = React.useContext(ThemeContext);
+  const { isDarkTheme } = useThemeContext();
   const marketplaceAssets = marketplaceThemedAssets(isDarkTheme || false);
 
   const [modalOpen, setModalOpen] = useState(false);

--- a/packages/components/src/components/MarketplaceSearch.tsx
+++ b/packages/components/src/components/MarketplaceSearch.tsx
@@ -15,7 +15,7 @@ import {
   IMarketplaceItemProps,
 } from '../types/components';
 import { marketplaceThemedAssets } from '../helpers/assets';
-import { ThemeContext } from '../helpers/theme';
+import { useThemeContext } from '../helpers/theme';
 
 export const MarketplaceSearch: React.FC<IMarketplaceSearchProps> = ({
   title,
@@ -25,7 +25,7 @@ export const MarketplaceSearch: React.FC<IMarketplaceSearchProps> = ({
   queryList,
   ...restProps
 }) => {
-  const { isDarkTheme } = React.useContext(ThemeContext);
+  const { isDarkTheme } = useThemeContext();
   const marketplaceAssets = marketplaceThemedAssets(isDarkTheme || false);
   const [items, setItems] = useState<Array<IMarketplaceItemProps> | null>(null);
   const [query, setQuery] = useState<string>();

--- a/packages/components/src/components/Modal.tsx
+++ b/packages/components/src/components/Modal.tsx
@@ -14,7 +14,7 @@ import {
 
 import { IModalProps } from '../types/components';
 import { modalThemedIcons } from '../helpers/assets';
-import { ThemeContext } from '../helpers/theme';
+import { useThemeContext } from '../helpers/theme';
 import { useKeyPress } from '../helpers/hooks';
 
 export const Modal: React.FC<IModalProps> = ({
@@ -27,7 +27,7 @@ export const Modal: React.FC<IModalProps> = ({
   onCancel,
   ...restProps
 }) => {
-  const { isDarkTheme } = React.useContext(ThemeContext);
+  const { isDarkTheme } = useThemeContext();
   const escapePress = useKeyPress('Escape');
   const icons = modalThemedIcons(isDarkTheme || false);
 

--- a/packages/components/src/components/Newsletter.tsx
+++ b/packages/components/src/components/Newsletter.tsx
@@ -2,14 +2,14 @@ import React, { useState } from 'react';
 import validator from 'validator';
 
 import { Form } from './Newsletter.styles';
-import { ThemeContext } from '../helpers/theme';
+import { useThemeContext } from '../helpers/theme';
 import { newsletterThemedIcons } from '../helpers/assets';
 import { INewsletterProps } from '../types/components';
 
 export const Newsletter: React.FC<INewsletterProps> = ({
   onNewsletterSubmit,
 }) => {
-  const { isDarkTheme } = React.useContext(ThemeContext);
+  const { isDarkTheme } = useThemeContext();
   const [inputValue, setInputValue] = useState<string>('');
   const [inputError, setInputError] = useState<boolean>(false);
   const icons = newsletterThemedIcons(isDarkTheme || false);

--- a/packages/components/src/components/SearchBar.tsx
+++ b/packages/components/src/components/SearchBar.tsx
@@ -29,7 +29,7 @@ import {
 import { ISearchBarProps } from '../types/components';
 import { searchBarThemedIcons } from '../helpers/assets';
 import { toggleLockBodyScroll } from '../helpers/modals';
-import { ThemeContext } from '../helpers/theme';
+import { useThemeContext } from '../helpers/theme';
 import { algoliaConfig } from '../configs';
 
 const algoliaClient = algoliaSearch(algoliaConfig.appID, algoliaConfig.apiKey, {
@@ -64,7 +64,7 @@ const searchClient: Pick<typeof algoliaClient, 'search'> = {
 };
 
 function useIcons() {
-  const { isDarkTheme } = React.useContext(ThemeContext);
+  const { isDarkTheme } = useThemeContext();
   return searchBarThemedIcons(isDarkTheme || false);
 }
 

--- a/packages/components/src/components/Subheader.tsx
+++ b/packages/components/src/components/Subheader.tsx
@@ -12,7 +12,7 @@ import {
 } from './Subheader.styles';
 
 import { ISubheaderProps } from '../types/components';
-import { ThemeContext } from '../helpers/theme';
+import { useThemeContext } from '../helpers/theme';
 import { headerThemedIcons } from '../helpers/assets';
 import { toggleLockBodyScroll } from '../helpers/modals';
 
@@ -23,7 +23,7 @@ export const Subheader: React.FC<ISubheaderProps> = ({
   cta,
   ...restProps
 }) => {
-  const { isDarkTheme } = React.useContext(ThemeContext);
+  const { isDarkTheme } = useThemeContext();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   const icons = headerThemedIcons(isDarkTheme || false);

--- a/packages/components/src/helpers/theme.tsx
+++ b/packages/components/src/helpers/theme.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 
 const getDarkTheme = () => {
   if (typeof window !== 'undefined' && window.localStorage) {
@@ -76,4 +76,15 @@ const ThemeProvider: React.FC<IProviderProps> = ({
   );
 };
 
-export { ThemeContext, ThemeProvider };
+const useThemeContext = (): Partial<IContextProps> => {
+  const context = useContext(ThemeContext);
+  if (context == null) {
+    throw new Error(
+      '"useThemeContext" could not be used.',
+    );
+  }
+  return context;
+}
+
+export { ThemeContext, ThemeProvider, useThemeContext };
+

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -16,4 +16,4 @@ export { SearchBar } from './components/SearchBar';
 export { Subheader } from './components/Subheader';
 
 export { GlobalStyles } from './helpers/styles';
-export { ThemeProvider } from './helpers/theme';
+export { ThemeContext, ThemeProvider, useThemeContext } from './helpers/theme';


### PR DESCRIPTION
Added & exported `useThemeContext`. Used inside components & on sites where context is needed (e.g. [graphql-code-generator](https://github.com/dotansimha/graphql-code-generator))