### PR TITLE
Global Styles enhancement

### DIFF
--- a/.changeset/sixty-mangos-walk.md
+++ b/.changeset/sixty-mangos-walk.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': patch
+---
+
+Enhanced Global Styles to allow various configurations

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -14,7 +14,7 @@ export const parameters = {
 export const decorators = [
   (Story) => (
     <ThemeProvider>
-      <GlobalStyles includeFonts/>
+      <GlobalStyles includeFonts includeBase/>
       <Story />
     </ThemeProvider>
   ),

--- a/examples/nextjs/pages/_app.tsx
+++ b/examples/nextjs/pages/_app.tsx
@@ -8,6 +8,11 @@ import {
   ThemeProvider,
 } from '@theguild/components';
 
+// Overwrite font example:
+// 1. Import the font
+// 2. Remove `includeFonts` from `<GlobalStyles />`
+// import '../public/styles.css';
+
 export default function App({
   router,
   pageProps,
@@ -15,7 +20,7 @@ export default function App({
 }: AppProps): ReactElement {
   return (
     <>
-      <GlobalStyles includeFonts/>
+      <GlobalStyles includeBase includeFonts/>
       <ThemeProvider>
         <Header accentColor="#1cc8ee" activeLink="/open-source" themeSwitch />
         <Subheader

--- a/examples/nextjs/public/styles.css
+++ b/examples/nextjs/public/styles.css
@@ -1,0 +1,270 @@
+/* cyrillic-ext */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 100;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhGq3-OXg.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 100;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhPq3-OXg.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 100;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhIq3-OXg.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 100;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhEq3-OXg.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 100;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhFq3-OXg.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 100;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhLq38.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhGq3-OXg.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhPq3-OXg.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhIq3-OXg.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhEq3-OXg.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhFq3-OXg.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhLq38.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhGq3-OXg.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhPq3-OXg.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhIq3-OXg.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhEq3-OXg.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhFq3-OXg.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhLq38.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhGq3-OXg.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhPq3-OXg.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhIq3-OXg.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhEq3-OXg.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhFq3-OXg.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhLq38.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhGq3-OXg.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhPq3-OXg.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhIq3-OXg.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhEq3-OXg.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhFq3-OXg.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'TGCFont';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/robotomono/v13/L0x5DF4xlVMF-BfR8bXMIjhLq38.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}

--- a/packages/components/src/components/CardsColorful.styles.tsx
+++ b/packages/components/src/components/CardsColorful.styles.tsx
@@ -6,7 +6,7 @@ interface IStyleProps {
 }
 
 export const Wrapper = styled.section(() => [
-  tw`bg-white dark:bg-gray-900 py-8`,
+  tw`bg-white dark:bg-gray-900 py-8 font-default`,
 ]);
 
 export const Container = styled.div(() => [

--- a/packages/components/src/components/FeatureList.styles.tsx
+++ b/packages/components/src/components/FeatureList.styles.tsx
@@ -1,6 +1,6 @@
 import tw, { css, styled } from 'twin.macro';
 
-export const Wrapper = styled.section(() => [tw`bg-white dark:bg-gray-900`]);
+export const Wrapper = styled.section(() => [tw`bg-white dark:bg-gray-900 font-default`]);
 
 export const Container = styled.div(() => [tw`container-min py-14`]);
 

--- a/packages/components/src/components/Footer.styles.tsx
+++ b/packages/components/src/components/Footer.styles.tsx
@@ -1,7 +1,7 @@
 import tw, { css, styled } from 'twin.macro';
 
 export const Wrapper = styled.footer(() => [
-  tw`bg-white dark:bg-gray-900 text-xs`,
+  tw`bg-white dark:bg-gray-900 text-xs font-default`,
 ]);
 
 export const Container = styled.div(() => [

--- a/packages/components/src/components/FooterExtended.styles.tsx
+++ b/packages/components/src/components/FooterExtended.styles.tsx
@@ -1,7 +1,7 @@
 import tw, { css, styled } from 'twin.macro';
 
 export const Wrapper = styled.footer(() => [
-  tw`bg-white dark:bg-gray-900 text-xs`,
+  tw`bg-white dark:bg-gray-900 text-xs font-default`,
 ]);
 
 export const Container = styled.div(() => [tw`container-max`]);

--- a/packages/components/src/components/Header.styles.tsx
+++ b/packages/components/src/components/Header.styles.tsx
@@ -8,8 +8,7 @@ interface IStyleProps {
 }
 
 export const Wrapper = styled.header(() => [
-  tw`py-2 md:py-5`,
-  tw`bg-white dark:bg-gray-900`,
+  tw`py-2 md:py-5 bg-white dark:bg-gray-900 font-default`,
   css`
     button:focus:not(:focus-visible) {
       ${tw`outline-none!`}

--- a/packages/components/src/components/HeroGradient.styles.tsx
+++ b/packages/components/src/components/HeroGradient.styles.tsx
@@ -6,7 +6,7 @@ interface IStyleProps {
 }
 
 export const Wrapper = styled.section(() => [
-  tw`bg-white dark:bg-gray-900 overflow-hidden md:pt-14`,
+  tw`bg-white dark:bg-gray-900 overflow-hidden md:pt-14 font-default`,
 ]);
 
 export const Container = styled.div(() => [tw`container-min relative`]);

--- a/packages/components/src/components/HeroIllustration.styles.tsx
+++ b/packages/components/src/components/HeroIllustration.styles.tsx
@@ -5,7 +5,7 @@ interface IStyleProps {
   flipped?: boolean;
 }
 
-export const Wrapper = styled.section(() => [tw`bg-white dark:bg-gray-900`]);
+export const Wrapper = styled.section(() => [tw`bg-white dark:bg-gray-900 font-default`]);
 
 export const Container = styled.div(({ flipped }: IStyleProps) => [
   tw`container-min flex flex-wrap items-center py-8`,

--- a/packages/components/src/components/HeroMarketplace.styles.tsx
+++ b/packages/components/src/components/HeroMarketplace.styles.tsx
@@ -6,7 +6,7 @@ interface IStyleProps {
 }
 
 export const Wrapper = styled.section(() => [
-  tw`overflow-hidden bg-white dark:bg-gray-900`,
+  tw`overflow-hidden bg-white dark:bg-gray-900 font-default`,
 ]);
 
 export const Container = styled.div(() => [tw`relative`]);

--- a/packages/components/src/components/HeroVideo.styles.tsx
+++ b/packages/components/src/components/HeroVideo.styles.tsx
@@ -5,7 +5,7 @@ interface IStyleProps {
   flipped?: boolean;
 }
 
-export const Wrapper = styled.section(() => [tw`bg-gray-100 dark:bg-gray-800`]);
+export const Wrapper = styled.section(() => [tw`bg-gray-100 dark:bg-gray-800 font-default`]);
 
 export const Container = styled.div(({ flipped }: IStyleProps) => [
   tw`container-min flex flex-wrap py-8`,

--- a/packages/components/src/components/InfoList.styles.tsx
+++ b/packages/components/src/components/InfoList.styles.tsx
@@ -1,7 +1,7 @@
 import tw, { css, styled, theme } from 'twin.macro';
 import { rgba } from 'polished';
 
-export const Wrapper = styled.section(() => [tw`bg-white dark:bg-gray-900`]);
+export const Wrapper = styled.section(() => [tw`bg-white dark:bg-gray-900 font-default`]);
 
 export const Container = styled.div(() => [tw`container-min py-12`]);
 

--- a/packages/components/src/components/MarketplaceList.styles.tsx
+++ b/packages/components/src/components/MarketplaceList.styles.tsx
@@ -1,7 +1,7 @@
 import tw, { css, styled } from 'twin.macro';
 
 export const Wrapper = styled.section(() => [
-  tw`w-full bg-white dark:bg-gray-900`,
+  tw`w-full bg-white dark:bg-gray-900 font-default`,
 ]);
 
 export const Container = styled.div(() => [tw`container-max py-6`]);
@@ -89,7 +89,7 @@ export const TableItemInfo = styled.div(() => [
     min-height: 5rem;
 
     a {
-      ${tw`flex items-center hocus:opacity-75 transition duration-150 ease-in-out`}
+      ${tw`flex items-center text-gray-500 dark:text-gray-400 hocus:opacity-75 transition duration-150 ease-in-out no-underline`}
     }
 
     h3 {

--- a/packages/components/src/components/MarketplaceSearch.styles.tsx
+++ b/packages/components/src/components/MarketplaceSearch.styles.tsx
@@ -1,6 +1,6 @@
 import tw, { css, styled } from 'twin.macro';
 
-export const Wrapper = styled.section(() => [tw`bg-white dark:bg-gray-900`]);
+export const Wrapper = styled.section(() => [tw`bg-white dark:bg-gray-900 font-default`]);
 
 export const Container = styled.div(() => [tw`container-max py-12`]);
 

--- a/packages/components/src/components/Modal.styles.tsx
+++ b/packages/components/src/components/Modal.styles.tsx
@@ -6,7 +6,7 @@ interface IStyleProps {
 }
 
 export const Container = styled.div(({ isModalOpen }: IStyleProps) => [
-  tw`fixed inset-0 visible`,
+  tw`fixed inset-0 visible font-default`,
   css`
     z-index: 400; //TODO: Used for Docusaurus, remove when no longer needed.
     button:focus:not(:focus-visible) {

--- a/packages/components/src/components/Newsletter.styles.tsx
+++ b/packages/components/src/components/Newsletter.styles.tsx
@@ -5,7 +5,7 @@ interface IStyleProps {
 }
 
 export const Form = styled.form(({ hasError }: IStyleProps) => [
-  tw`flex items-center bg-gray-100 border-2 border-gray-100 rounded-md`,
+  tw`flex items-center bg-gray-100 border-2 border-gray-100 rounded-md font-default`,
   tw`dark:(bg-gray-800 border-gray-800)`,
   css`
     span {

--- a/packages/components/src/components/SearchBar.styles.tsx
+++ b/packages/components/src/components/SearchBar.styles.tsx
@@ -6,7 +6,7 @@ interface IStyleProps {
 
 export const SearchButton = styled.button(
   ({ accentColor, isFull }: IStyleProps) => [
-    tw`flex items-center p-0 font-sans font-medium text-xs text-gray-500 bg-transparent border-transparent cursor-pointer`,
+    tw`flex items-center p-0 font-default font-medium text-xs text-gray-500 bg-transparent border-transparent cursor-pointer`,
     tw`md:(ml-3 pl-1 pr-8 py-1 border-2 bg-gray-100 rounded-md)`,
     tw`md:dark:(bg-gray-800 text-gray-300)`,
     tw`transition duration-200 ease-in-out`,
@@ -34,7 +34,7 @@ export const SearchButton = styled.button(
 );
 
 export const SearchForm = styled.div(({ accentColor }: IStyleProps) => [
-  tw`sticky -top-6 z-10 -m-6 p-6 bg-white shadow-sm`,
+  tw`sticky -top-6 z-10 -m-6 p-6 bg-white shadow-sm font-default`,
   tw`dark:bg-gray-900 bg-white`,
   css`
     form {

--- a/packages/components/src/components/Subheader.stories.tsx
+++ b/packages/components/src/components/Subheader.stories.tsx
@@ -20,7 +20,7 @@ export default {
     },
     activeLink: {
       name: 'Active Link',
-      options: ['/', '/marketplace', '/features', '/docs'],
+      options: ['/', '/marketplace', '/features', '/docs/introduction'],
       control: {
         type: 'radio',
       },

--- a/packages/components/src/components/Subheader.styles.tsx
+++ b/packages/components/src/components/Subheader.styles.tsx
@@ -8,7 +8,7 @@ interface IStyleProps {
 }
 
 export const Wrapper = styled.header(() => [
-  tw`sticky top-0 z-10 py-5 bg-white dark:bg-gray-900`,
+  tw`sticky top-0 z-10 py-5 bg-white dark:bg-gray-900 font-default`,
   css`
     box-shadow: 0px 16px 20px rgba(0, 0, 0, 0.04);
     button:focus:not(:focus-visible) {

--- a/packages/components/src/components/Subheader.tsx
+++ b/packages/components/src/components/Subheader.tsx
@@ -33,11 +33,11 @@ export const Subheader: React.FC<ISubheaderProps> = ({
     setMobileNavOpen(state);
   };
 
-  links.map((link) => {
+  links.forEach((link) => {
     if (link.href === '/') {
       link.active = activeLink === link.href;
     } else {
-      link.active = activeLink.includes(link.href);
+      link.active = activeLink.startsWith(link.href);
     }
   });
 

--- a/packages/components/src/helpers/styles.tsx
+++ b/packages/components/src/helpers/styles.tsx
@@ -10,44 +10,10 @@ const customStyles = css`
   }
 `;
 
-const fontStyles = css`
+const defaultFontFace = css`
   /* devanagari */
   @font-face {
-    font-family: 'Poppins';
-    font-style: italic;
-    font-weight: 600;
-    font-display: swap;
-    src: url('https://fonts.gstatic.com/s/poppins/v15/pxiDyp8kv8JHgFVrJJLmr19VFteOcEg.woff2')
-      format('woff2');
-    unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8,
-      U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
-  }
-  /* latin-ext */
-  @font-face {
-    font-family: 'Poppins';
-    font-style: italic;
-    font-weight: 600;
-    font-display: swap;
-    src: url('https://fonts.gstatic.com/s/poppins/v15/pxiDyp8kv8JHgFVrJJLmr19VGdeOcEg.woff2')
-      format('woff2');
-    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
-      U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-  }
-  /* latin */
-  @font-face {
-    font-family: 'Poppins';
-    font-style: italic;
-    font-weight: 600;
-    font-display: swap;
-    src: url('https://fonts.gstatic.com/s/poppins/v15/pxiDyp8kv8JHgFVrJJLmr19VF9eO.woff2')
-      format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-      U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
-      U+2215, U+FEFF, U+FFFD;
-  }
-  /* devanagari */
-  @font-face {
-    font-family: 'Poppins';
+    font-family: 'TGCFont';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
@@ -58,7 +24,7 @@ const fontStyles = css`
   }
   /* latin-ext */
   @font-face {
-    font-family: 'Poppins';
+    font-family: 'TGCFont';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
@@ -69,7 +35,7 @@ const fontStyles = css`
   }
   /* latin */
   @font-face {
-    font-family: 'Poppins';
+    font-family: 'TGCFont';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
@@ -81,7 +47,7 @@ const fontStyles = css`
   }
   /* devanagari */
   @font-face {
-    font-family: 'Poppins';
+    font-family: 'TGCFont';
     font-style: normal;
     font-weight: 500;
     font-display: swap;
@@ -92,7 +58,7 @@ const fontStyles = css`
   }
   /* latin-ext */
   @font-face {
-    font-family: 'Poppins';
+    font-family: 'TGCFont';
     font-style: normal;
     font-weight: 500;
     font-display: swap;
@@ -103,7 +69,7 @@ const fontStyles = css`
   }
   /* latin */
   @font-face {
-    font-family: 'Poppins';
+    font-family: 'TGCFont';
     font-style: normal;
     font-weight: 500;
     font-display: swap;
@@ -115,7 +81,7 @@ const fontStyles = css`
   }
   /* devanagari */
   @font-face {
-    font-family: 'Poppins';
+    font-family: 'TGCFont';
     font-style: normal;
     font-weight: 700;
     font-display: swap;
@@ -124,9 +90,43 @@ const fontStyles = css`
     unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8,
       U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
   }
+  /* devanagari */
+  @font-face {
+    font-family: 'TGCFont';
+    font-style: italic;
+    font-weight: 600;
+    font-display: swap;
+    src: url('https://fonts.gstatic.com/s/poppins/v15/pxiDyp8kv8JHgFVrJJLmr19VFteOcEg.woff2')
+      format('woff2');
+    unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8,
+      U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
+  }
   /* latin-ext */
   @font-face {
-    font-family: 'Poppins';
+    font-family: 'TGCFont';
+    font-style: italic;
+    font-weight: 600;
+    font-display: swap;
+    src: url('https://fonts.gstatic.com/s/poppins/v15/pxiDyp8kv8JHgFVrJJLmr19VGdeOcEg.woff2')
+      format('woff2');
+    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
+      U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  }
+  /* latin */
+  @font-face {
+    font-family: 'TGCFont';
+    font-style: italic;
+    font-weight: 600;
+    font-display: swap;
+    src: url('https://fonts.gstatic.com/s/poppins/v15/pxiDyp8kv8JHgFVrJJLmr19VF9eO.woff2')
+      format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+      U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
+      U+2215, U+FEFF, U+FFFD;
+  }
+  /* latin-ext */
+  @font-face {
+    font-family: 'TGCFont';
     font-style: normal;
     font-weight: 700;
     font-display: swap;
@@ -137,7 +137,7 @@ const fontStyles = css`
   }
   /* latin */
   @font-face {
-    font-family: 'Poppins';
+    font-family: 'TGCFont';
     font-style: normal;
     font-weight: 700;
     font-display: swap;
@@ -147,15 +147,11 @@ const fontStyles = css`
       U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
       U+2215, U+FEFF, U+FFFD;
   }
-
-  body {
-    font-family: 'Poppins', 'sans-serif';
-  }
 `
 
-export const GlobalStyles: React.FC<IGlobalStyle> = ({includeFonts}) => (
+export const GlobalStyles: React.FC<IGlobalStyle> = ({includeFonts, includeBase}) => (
   <>
-    <BaseStyles />
-    <Global styles={includeFonts ? [customStyles, fontStyles] : customStyles} />
+    {includeBase && <BaseStyles />}
+    <Global styles={includeFonts ? [customStyles, defaultFontFace] : customStyles} />
   </>
 );

--- a/packages/components/src/types/components.ts
+++ b/packages/components/src/types/components.ts
@@ -9,7 +9,8 @@ interface IVideo {
 }
 
 export interface IGlobalStyle {
-  includeFonts?: boolean
+  includeFonts?: boolean;
+  includeBase?: boolean;
 }
 
 export interface ILink {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -60,6 +60,10 @@ module.exports = {
           ...containerProps,
           maxWidth: '1024px',
         },
+
+        '.font-default': {
+          fontFamily: 'TGCFont, sans-serif'
+        }
       };
 
       addUtilities(newUtilities);


### PR DESCRIPTION
Changes:

1. `<BaseStyle/>` is now optionally included within the Global Styles based on `includeBase`;
2. `includeFonts` now declares font _"Poppins"_ as _"TGCFont"_, allowing to:
- use the font within the components based on the class **.font-default** (configured in tailwind);
- omit the font declaration & overwrite it by declaring _"TGCFont"_ on website level (when Poppins font is not wanted; see nextjs example);