### PR TITLE
fix marketPlace formatDate

### DIFF
--- a/.changeset/late-cars-sit.md
+++ b/.changeset/late-cars-sit.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': patch
+---
+
+fix marketPlace formatDate

--- a/packages/components/src/components/MarketplaceList.tsx
+++ b/packages/components/src/components/MarketplaceList.tsx
@@ -35,7 +35,7 @@ const TableItems: React.FC<IMarketplaceItemsProps> = ({
   setCurrentItem,
   ...restProps
 }) => {
-  const formateDate = (value: string) => {
+  const formatDate = (value: string) => {
     const months = [
       'Jan',
       'Feb',
@@ -51,7 +51,7 @@ const TableItems: React.FC<IMarketplaceItemsProps> = ({
       'Dec',
     ];
     const date = new Date(value);
-    return `${months[date.getMonth()]} ${date.getDay()}, ${date.getFullYear()}`;
+    return `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
   };
 
   return (
@@ -81,7 +81,7 @@ const TableItems: React.FC<IMarketplaceItemsProps> = ({
               </TableItemInfo>
             </td>
             <td>
-              <TableItemDate {...restProps.dateProps}>{formateDate(item.update)}</TableItemDate>
+              <TableItemDate {...restProps.dateProps}>{formatDate(item.update)}</TableItemDate>
             </td>
             <td>
               <TableItemButton


### PR DESCRIPTION
formatDate should've been "getDate" and not "getDay"

![image](https://user-images.githubusercontent.com/8672915/124967729-bcf22e80-dff2-11eb-8c29-8aa49667f7de.png)

![image](https://user-images.githubusercontent.com/8672915/124967744-c11e4c00-dff2-11eb-8313-d8a840cdeb5c.png)


I realized about this issue after reading wrong days in the plugin hubs
