### PR TITLE
fix(components): algolia host should not contain redirect (www.)

### DIFF
--- a/.changeset/yellow-suits-glow.md
+++ b/.changeset/yellow-suits-glow.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+fix(components): algolia host should not contain redirect (www.)

--- a/packages/components/src/configs.ts
+++ b/packages/components/src/configs.ts
@@ -4,7 +4,7 @@ export const algoliaConfig = {
   searchIndex: 'theguild',
   hosts: [
     {
-      url: 'the-guild.dev/api/algolia',
+      url: 'www.the-guild.dev/api/algolia',
     },
   ],
 };


### PR DESCRIPTION
The DNS redirect on `the-guild.dev` is breaking CORS for Algolia search requests to our lambda proxy