### PR TITLE
Allow to transform links of Header component

### DIFF
--- a/.changeset/polite-badgers-shake.md
+++ b/.changeset/polite-badgers-shake.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': minor
+---
+
+Allow to transform links of Header component

--- a/packages/components/src/components/Header.tsx
+++ b/packages/components/src/components/Header.tsx
@@ -23,6 +23,7 @@ export const Header: React.FC<IHeaderProps> = ({
   accentColor,
   activeLink,
   themeSwitch,
+  transformLinks = (links) => links,
   ...restProps
 }) => {
   const { isDarkTheme, setDarkTheme } = useThemeContext();
@@ -62,7 +63,7 @@ export const Header: React.FC<IHeaderProps> = ({
     };
   };
 
-  const links = [
+  const links = transformLinks([
     {
       label: 'Our Services',
       title: 'View our services',
@@ -84,7 +85,7 @@ export const Header: React.FC<IHeaderProps> = ({
       title: 'Learn more about us',
       href: '/about-us',
     },
-  ];
+  ]);
 
   const onLinkClick = restProps.linkProps?.onClick;
 

--- a/packages/components/src/types/components.ts
+++ b/packages/components/src/types/components.ts
@@ -30,10 +30,19 @@ export interface IButtonProps {
   variant?: string;
 }
 
+export interface IHeaderLink {
+  label: string;
+  title: string;
+  href: string;
+  onClick?: () => void;
+}
+
 export interface IHeaderProps {
   accentColor: string;
   activeLink: string;
   themeSwitch?: boolean;
+
+  transformLinks?: (links: IHeaderLink[]) => IHeaderLink[];
 
   wrapperProps?: React.ComponentProps<'header'>;
   containerProps?: React.ComponentProps<'div'>;


### PR DESCRIPTION
The idea here is to customise the links (append, prepend, modify) depending on the website the component is used on. The Guild's website is missing a link to `/contact` page but it's not needed in docs.