### PR TITLE
always use `images.unoptimized`

### DIFF
--- a/.changeset/little-ducks-lay.md
+++ b/.changeset/little-ducks-lay.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': patch
+---
+
+always use `images.unoptimized`

--- a/packages/components/src/next.config.ts
+++ b/packages/components/src/next.config.ts
@@ -40,10 +40,6 @@ export const withGuildDocs = ({
     },
   });
 
-  const isNextExport =
-    process.env.npm_lifecycle_script?.includes('next export') ||
-    process.env.npm_config_argv?.includes('"next","export"');
-
   return withBundleAnalyzer(
     withVideos(
       withNextra({
@@ -62,12 +58,10 @@ export const withGuildDocs = ({
           newNextLinkBehavior: true,
           ...nextConfig.experimental,
         },
-        ...(isNextExport && {
-          images: {
-            unoptimized: true, // doesn't work with `next export`,
-            ...nextConfig.images,
-          },
-        }),
+        images: {
+          unoptimized: true, // doesn't work with `next export`,
+          ...nextConfig.images,
+        },
       })
     )
   );


### PR DESCRIPTION
saw if `next build` was without `images.unoptimized` and after we run `next export` with `images.unoptimized`

we can get some unexpected behaviour
<img width="1574" alt="image" src="https://user-images.githubusercontent.com/7361780/195368216-658728d7-b871-4f7d-867a-b832822569da.png">

let's just enable it always