### PR TITLE
Tabs in search params

### DIFF
--- a/.changeset/lovely-feet-float.md
+++ b/.changeset/lovely-feet-float.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': minor
+---
+
+Extract Tabs component from Nextra

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@storybook/nextjs": "8.4.2",
     "@storybook/preview-api": "8.4.2",
     "@storybook/react": "8.4.2",
+    "@storybook/test": "^8.4.2",
     "@storybook/theming": "8.4.2",
     "@svgr/webpack": "8.1.0",
     "@theguild/eslint-config": "0.13.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,7 +47,8 @@
     "@theguild/tailwind-config": "^0.6.3",
     "next": "^13 || ^14 || ^15.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@headlessui/react": "2.2.0"
   },
   "dependencies": {
     "@giscus/react": "3.1.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,11 +44,11 @@
     "types:check": "tsc --noEmit"
   },
   "peerDependencies": {
+    "@headlessui/react": "2.2.0",
     "@theguild/tailwind-config": "^0.6.3",
     "next": "^13 || ^14 || ^15.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@headlessui/react": "2.2.0"
+    "react-dom": "^18.2.0"
   },
   "dependencies": {
     "@giscus/react": "3.1.0",

--- a/packages/components/src/components/legacy-package-cmd.tsx
+++ b/packages/components/src/components/legacy-package-cmd.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useMemo } from 'react';
-import { Pre, Tabs } from 'nextra/components';
+import { Pre } from 'nextra/components';
+import { Tabs } from './tabs';
 
 const PACKAGE_MANAGERS = ['yarn', 'npm', 'pnpm'];
 

--- a/packages/components/src/components/marketplace-search.tsx
+++ b/packages/components/src/components/marketplace-search.tsx
@@ -2,12 +2,12 @@
 
 import { isValidElement, ReactElement, useMemo, useState } from 'react';
 import fuzzy from 'fuzzy';
-import { Tabs } from './tabs';
 import { cn } from '../cn';
 import { IMarketplaceListProps, IMarketplaceSearchProps } from '../types/components';
 import { Heading } from './heading';
 import { CloseIcon, SearchIcon } from './icons';
 import { MarketplaceList } from './marketplace-list';
+import { Tabs } from './tabs';
 import { Tag, TagsContainer } from './tag';
 
 const renderQueryPlaceholder = (placeholder: string | ReactElement, query: string) => {

--- a/packages/components/src/components/marketplace-search.tsx
+++ b/packages/components/src/components/marketplace-search.tsx
@@ -2,7 +2,7 @@
 
 import { isValidElement, ReactElement, useMemo, useState } from 'react';
 import fuzzy from 'fuzzy';
-import { Tabs } from 'nextra/components';
+import { Tabs } from './tabs';
 import { cn } from '../cn';
 import { IMarketplaceListProps, IMarketplaceSearchProps } from '../types/components';
 import { Heading } from './heading';

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -23,7 +23,7 @@ import {
   TabPanel,
   TabPanelProps,
   TabPanels,
-  // this component is almost verbatim copied from Nextra, so keep @headlessui/react to guarantee it works the same
+  // this component is almost verbatim copied from Nextra, so we keep @headlessui/react to guarantee it works the same
 } from '@headlessui/react';
 import { useHash } from '../use-hash';
 
@@ -50,10 +50,11 @@ export interface TabsProps
   searchParamKey?: string;
   /**
    * LocalStorage key for persisting the selected tab.
-   * Defaults to `tabs-${id}` if not provided.
+   * Set to `true` to use the default key `tabs-${id}`.
    * Set to `null` to disable localStorage persistence.
+   * Set to a string to use a custom key.
    */
-  storageKey?: string | null;
+  storageKey?: string | true | null;
   /** Tabs CSS class name. */
   className?: TabListProps['className'];
   /** Tab CSS class name. */
@@ -73,7 +74,7 @@ export const Tabs = ({
 }: TabsProps) => {
   const id = useId();
 
-  if (storageKey === undefined) {
+  if (storageKey === true) {
     storageKey = `tabs-${id}`;
   }
 

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { FC, Fragment, ReactElement, ReactNode, useEffect, useId, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import cn from 'clsx';
 import {
   Tab as HeadlessTab,
@@ -79,6 +80,16 @@ export const Tabs = ({
     }
     setSelectedIndex(index);
     onChange?.(index);
+
+    if (searchParamKey) {
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.set(searchParamKey, getTabKey(items, index));
+      window.history.replaceState(
+        null,
+        '',
+        `${window.location.pathname}?${searchParams.toString()}`,
+      );
+    }
   };
 
   return (
@@ -165,6 +176,8 @@ function useActiveTabFromURL(
   setSelectedIndex: (index: number) => void,
 ) {
   const hash = useHash();
+  const searchParams = useSearchParams();
+  const tabsInSearchParams = searchParams.getAll(searchParamKey).sort();
 
   useEffect(() => {
     if (!hash) return;
@@ -185,19 +198,14 @@ function useActiveTabFromURL(
           requestAnimationFrame(() => (location.hash = `#${hash}`));
         }
       }
-    } else {
+    } else if (tabsInSearchParams) {
       // if we don't have content to scroll to, we look at the search params
-      const searchParams = new URLSearchParams(window.location.search);
-      const tabKey = searchParams.get(searchParamKey);
-      if (tabKey) {
-        const index = items.findIndex((_, i) => getTabKey(items, i) === tabKey);
-        setSelectedIndex(index);
-        return;
-      }
+      const index = items.findIndex((_, i) => tabsInSearchParams.includes(getTabKey(items, i)));
+      if (index !== -1) setSelectedIndex(index);
     }
     // tabPanelsRef is a ref, so it's not a dependency
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hash]);
+  }, [hash, tabsInSearchParams.join(',')]);
 }
 
 function useActiveTabFromStorage(

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -227,14 +227,6 @@ function useActiveTabFromURL(
     tabsInSearchParams.includes(getTabKey(items, index, id)),
   );
 
-  console.log({
-    searchParams,
-    tabIndexFromSearchParams,
-    tabsInSearchParams,
-    items,
-    id,
-  });
-
   useIsomorphicLayoutEffect(() => {
     const tabPanel = hash
       ? tabPanelsRef.current?.querySelector(`[role=tabpanel]:has([id="${hash}"])`)

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { FC, Fragment, ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
+import cn from 'clsx';
+import {
+  Tab as HeadlessTab,
+  TabProps as HeadlessTabProps,
+  TabGroup,
+  TabGroupProps,
+  TabList,
+  TabListProps,
+  TabPanel,
+  TabPanelProps,
+  TabPanels,
+  // this component is almost verbatim copied from Nextra, so keep @headlessui/react to guarantee it works the same
+} from '@headlessui/react';
+import { useHash } from '../use-hash';
+
+type TabItem = string | ReactElement;
+
+type TabObjectItem = {
+  label: TabItem;
+  disabled: boolean;
+};
+
+function isTabObjectItem(item: unknown): item is TabObjectItem {
+  return !!item && typeof item === 'object' && 'label' in item;
+}
+
+export interface TabsProps
+  extends Pick<TabGroupProps, 'defaultIndex' | 'selectedIndex' | 'onChange'> {
+  items: (TabItem | TabObjectItem)[];
+  children: ReactNode;
+  /** LocalStorage key for persisting the selected tab. */
+  storageKey?: string;
+  /** Tabs CSS class name. */
+  className?: TabListProps['className'];
+  /** Tab CSS class name. */
+  tabClassName?: HeadlessTabProps['className'];
+}
+
+export const Tabs = ({
+  items,
+  children,
+  storageKey,
+  defaultIndex = 0,
+  selectedIndex: _selectedIndex,
+  onChange,
+  className,
+  tabClassName,
+}: TabsProps) => {
+  const [selectedIndex, setSelectedIndex] = useState(defaultIndex);
+  const hash = useHash();
+  const tabPanelsRef = useRef<HTMLDivElement>(null!);
+
+  useEffect(() => {
+    if (_selectedIndex !== undefined) {
+      setSelectedIndex(_selectedIndex);
+    }
+  }, [_selectedIndex]);
+
+  useEffect(() => {
+    if (!hash) return;
+    const tabPanel = tabPanelsRef.current.querySelector(`[role=tabpanel]:has([id="${hash}"])`);
+    if (!tabPanel) return;
+
+    for (const [index, el] of Object.entries(tabPanelsRef.current.children)) {
+      if (el === tabPanel) {
+        setSelectedIndex(Number(index));
+        // Clear hash first, otherwise page isn't scrolled
+        location.hash = '';
+        // Execute on next tick after `selectedIndex` update
+        requestAnimationFrame(() => {
+          location.hash = `#${hash}`;
+        });
+      }
+    }
+  }, [hash]);
+
+  useEffect(() => {
+    if (!storageKey) {
+      // Do not listen storage events if there is no storage key
+      return;
+    }
+
+    function fn(event: StorageEvent) {
+      if (event.key === storageKey) {
+        setSelectedIndex(Number(event.newValue));
+      }
+    }
+
+    const index = Number(localStorage.getItem(storageKey));
+    setSelectedIndex(Number.isNaN(index) ? 0 : index);
+
+    window.addEventListener('storage', fn);
+    return () => {
+      window.removeEventListener('storage', fn);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- only on mount
+
+  const handleChange = (index: number) => {
+    if (storageKey) {
+      const newValue = String(index);
+      localStorage.setItem(storageKey, newValue);
+
+      // the storage event only get picked up (by the listener) if the localStorage was changed in
+      // another browser's tab/window (of the same app), but not within the context of the current tab.
+      window.dispatchEvent(new StorageEvent('storage', { key: storageKey, newValue }));
+      return;
+    }
+    setSelectedIndex(index);
+    onChange?.(index);
+  };
+
+  return (
+    <TabGroup
+      selectedIndex={selectedIndex}
+      defaultIndex={defaultIndex}
+      onChange={handleChange}
+      as={Fragment}
+    >
+      <TabList
+        className={args =>
+          cn(
+            'nextra-scrollbar x:overflow-x-auto x:overscroll-x-contain x:overflow-y-hidden',
+            'x:mt-4 x:flex x:w-full x:gap-2 x:border-b x:border-gray-200 x:pb-px x:dark:border-neutral-800',
+            'x:focus-visible:nextra-focus',
+            typeof className === 'function' ? className(args) : className,
+          )
+        }
+      >
+        {items.map((item, index) => (
+          <HeadlessTab
+            key={index}
+            disabled={isTabObjectItem(item) && item.disabled}
+            className={args => {
+              const { selected, disabled, hover, focus } = args;
+              return cn(
+                focus && 'x:nextra-focus x:ring-inset',
+                'x:whitespace-nowrap x:cursor-pointer',
+                'x:rounded-t x:p-2 x:font-medium x:leading-5 x:transition-colors',
+                'x:-mb-0.5 x:select-none x:border-b-2',
+                selected
+                  ? 'x:border-current x:outline-none'
+                  : hover
+                    ? 'x:border-gray-200 x:dark:border-neutral-800'
+                    : 'x:border-transparent',
+                selected
+                  ? 'x:text-primary-600'
+                  : disabled
+                    ? 'x:text-gray-400 x:dark:text-neutral-600 x:pointer-events-none'
+                    : hover
+                      ? 'x:text-black x:dark:text-white'
+                      : 'x:text-gray-600 x:dark:text-gray-200',
+                typeof tabClassName === 'function' ? tabClassName(args) : tabClassName,
+              );
+            }}
+          >
+            {isTabObjectItem(item) ? item.label : item}
+          </HeadlessTab>
+        ))}
+      </TabList>
+      <TabPanels ref={tabPanelsRef}>{children}</TabPanels>
+    </TabGroup>
+  );
+};
+
+export const Tab: FC<TabPanelProps> = ({
+  children,
+  // For SEO display all the Panel in the DOM and set `display: none;` for those that are not selected
+  unmount = false,
+  className,
+  ...props
+}) => {
+  return (
+    <TabPanel
+      {...props}
+      unmount={unmount}
+      className={args =>
+        cn(
+          'x:rounded x:mt-[1.25em]',
+          args.focus && 'x:nextra-focus',
+          typeof className === 'function' ? className(args) : className,
+        )
+      }
+    >
+      {children}
+    </TabPanel>
+  );
+};

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -48,8 +48,12 @@ export interface TabsProps
    * @default "tab"
    */
   searchParamKey?: string;
-  /** LocalStorage key for persisting the selected tab. */
-  storageKey?: string;
+  /**
+   * LocalStorage key for persisting the selected tab.
+   * Defaults to `tabs-${id}` if not provided.
+   * Set to `null` to disable localStorage persistence.
+   */
+  storageKey?: string | null;
   /** Tabs CSS class name. */
   className?: TabListProps['className'];
   /** Tab CSS class name. */
@@ -69,7 +73,9 @@ export const Tabs = ({
 }: TabsProps) => {
   const id = useId();
 
-  storageKey ??= `tabs-${id}`;
+  if (storageKey === undefined) {
+    storageKey = `tabs-${id}`;
+  }
 
   let [selectedIndex, setSelectedIndex] = useState<number>(defaultIndex);
   if (_selectedIndex !== undefined) {
@@ -104,7 +110,23 @@ export const Tabs = ({
 
     if (searchParamKey) {
       const searchParams = new URLSearchParams(window.location.search);
-      searchParams.set(searchParamKey, getTabKey(items, index, id));
+      const tabKeys = new Set(searchParams.getAll(searchParamKey));
+
+      // we remove only tabs from this list from search params
+      for (let i = 0; i < items.length; i++) {
+        const key = getTabKey(items, i, id);
+        tabKeys.delete(key);
+      }
+
+      // we add tabs from outside of this list back
+      searchParams.delete(searchParamKey);
+      for (const key of tabKeys) {
+        searchParams.append(searchParamKey, key);
+      }
+
+      // and finally, we add the clicked tab
+      searchParams.append(searchParamKey, getTabKey(items, index, id));
+
       window.history.replaceState(
         null,
         '',
@@ -205,6 +227,14 @@ function useActiveTabFromURL(
     tabsInSearchParams.includes(getTabKey(items, index, id)),
   );
 
+  console.log({
+    searchParams,
+    tabIndexFromSearchParams,
+    tabsInSearchParams,
+    items,
+    id,
+  });
+
   useIsomorphicLayoutEffect(() => {
     const tabPanel = hash
       ? tabPanelsRef.current?.querySelector(`[role=tabpanel]:has([id="${hash}"])`)
@@ -248,7 +278,7 @@ function useActiveTabFromURL(
 }
 
 function useActiveTabFromStorage(
-  storageKey: string,
+  storageKey: string | null,
   items: (TabItem | TabObjectItem)[],
   setSelectedIndex: (index: number) => void,
   ignoreLocalStorage: boolean,

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -51,7 +51,7 @@ export interface TabsProps
   /**
    * LocalStorage key for persisting the selected tab.
    * Set to `true` to use the default key `tabs-${id}`.
-   * Set to `null` to disable localStorage persistence.
+   * Leave empty or set to `null` to disable localStorage persistence.
    * Set to a string to use a custom key.
    */
   storageKey?: string | true | null;
@@ -65,7 +65,7 @@ export const Tabs = ({
   items,
   children,
   searchParamKey = 'tab',
-  storageKey,
+  storageKey = null,
   defaultIndex = 0,
   selectedIndex: _selectedIndex,
   onChange,

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, Fragment, ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
+import { FC, Fragment, ReactElement, ReactNode, useEffect, useId, useRef, useState } from 'react';
 import cn from 'clsx';
 import {
   Tab as HeadlessTab,
@@ -19,6 +19,7 @@ import { useHash } from '../use-hash';
 type TabItem = string | ReactElement;
 
 type TabObjectItem = {
+  key?: string;
   label: TabItem;
   disabled: boolean;
 };
@@ -31,6 +32,11 @@ export interface TabsProps
   extends Pick<TabGroupProps, 'defaultIndex' | 'selectedIndex' | 'onChange'> {
   items: (TabItem | TabObjectItem)[];
   children: ReactNode;
+  /**
+   * URLSearchParams key for persisting the selected tab.
+   * @default "tab"
+   */
+  searchParamKey?: string;
   /** LocalStorage key for persisting the selected tab. */
   storageKey?: string;
   /** Tabs CSS class name. */
@@ -42,6 +48,7 @@ export interface TabsProps
 export const Tabs = ({
   items,
   children,
+  searchParamKey = 'tab',
   storageKey,
   defaultIndex = 0,
   selectedIndex: _selectedIndex,
@@ -49,60 +56,21 @@ export const Tabs = ({
   className,
   tabClassName,
 }: TabsProps) => {
-  const [selectedIndex, setSelectedIndex] = useState(defaultIndex);
-  const hash = useHash();
+  let [selectedIndex, setSelectedIndex] = useState<number>(defaultIndex);
+  if (_selectedIndex !== undefined) {
+    selectedIndex = _selectedIndex;
+  }
+
+  const setSelectedTab = (key: TabKey) => {
+    const index = items.findIndex((_, i) => getTabKey(items, i) === key);
+    setSelectedIndex(index);
+  };
+
   const tabPanelsRef = useRef<HTMLDivElement>(null!);
 
-  useEffect(() => {
-    if (_selectedIndex !== undefined) {
-      setSelectedIndex(_selectedIndex);
-    }
-  }, [_selectedIndex]);
-
-  useEffect(() => {
-    if (!hash) return;
-    const tabPanel = tabPanelsRef.current.querySelector(`[role=tabpanel]:has([id="${hash}"])`);
-    if (!tabPanel) return;
-
-    for (const [index, el] of Object.entries(tabPanelsRef.current.children)) {
-      if (el === tabPanel) {
-        setSelectedIndex(Number(index));
-        // Note for posterity:
-        //   This is not an infinite loop. Clearing and restoring the hash is necessary
-        //   for the browser to scroll to the element. The intermediate empty hash triggers
-        //   a hashchange event, but React bails out when restoring the same hash value,
-        //   preventing an infinite loop.
-
-        // Clear hash first, otherwise page isn't scrolled
-        location.hash = '';
-        // Execute on next tick after `selectedIndex` update
-        requestAnimationFrame(() => {
-          location.hash = `#${hash}`;
-        });
-      }
-    }
-  }, [hash]);
-
-  useEffect(() => {
-    if (!storageKey) {
-      // Do not listen storage events if there is no storage key
-      return;
-    }
-
-    function fn(event: StorageEvent) {
-      if (event.key === storageKey) {
-        setSelectedIndex(Number(event.newValue));
-      }
-    }
-
-    const index = Number(localStorage.getItem(storageKey));
-    setSelectedIndex(Number.isNaN(index) ? 0 : index);
-
-    window.addEventListener('storage', fn);
-    return () => {
-      window.removeEventListener('storage', fn);
-    };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- only on mount
+  useActiveTabFromURL(tabPanelsRef, searchParamKey, setSelectedIndex);
+  const id = useId();
+  useActiveTabFromStorage(storageKey ?? id, setSelectedTab);
 
   const handleChange = (index: number) => {
     if (storageKey) {
@@ -113,9 +81,8 @@ export const Tabs = ({
       // another browser's tab/window (of the same app), but not within the context of the current tab.
       window.dispatchEvent(new StorageEvent('storage', { key: storageKey, newValue }));
       return;
-    } else {
-      setSelectedIndex(index);
     }
+    setSelectedIndex(index);
     onChange?.(index);
   };
 
@@ -129,9 +96,9 @@ export const Tabs = ({
       <TabList
         className={args =>
           cn(
-            'nextra-scrollbar x:overflow-x-auto x:overscroll-x-contain x:overflow-y-hidden',
-            'x:mt-4 x:flex x:w-full x:gap-2 x:border-b x:border-gray-200 x:pb-px x:dark:border-neutral-800',
-            'x:focus-visible:nextra-focus',
+            'nextra-scrollbar overflow-x-auto overflow-y-hidden overscroll-x-contain',
+            'mt-4 flex w-full gap-2 border-b border-beige-200 pb-px dark:border-neutral-800',
+            'focus-visible:hive-focus',
             typeof className === 'function' ? className(args) : className,
           )
         }
@@ -143,22 +110,22 @@ export const Tabs = ({
             className={args => {
               const { selected, disabled, hover, focus } = args;
               return cn(
-                focus && 'x:nextra-focus x:ring-inset',
-                'x:whitespace-nowrap x:cursor-pointer',
-                'x:rounded-t x:p-2 x:font-medium x:leading-5 x:transition-colors',
-                'x:-mb-0.5 x:select-none x:border-b-2',
+                focus && 'hive-focus ring-inset',
+                'cursor-pointer whitespace-nowrap',
+                'rounded-t p-2 font-medium leading-5 transition-colors',
+                '-mb-0.5 select-none border-b-2',
                 selected
-                  ? 'x:border-current x:outline-none'
+                  ? 'border-current outline-none'
                   : hover
-                    ? 'x:border-gray-200 x:dark:border-neutral-800'
-                    : 'x:border-transparent',
+                    ? 'border-beige-200 dark:border-neutral-800'
+                    : 'border-transparent',
                 selected
-                  ? 'x:text-primary-600'
+                  ? 'text-green-900 dark:text-primary'
                   : disabled
-                    ? 'x:text-gray-400 x:dark:text-neutral-600 x:pointer-events-none'
+                    ? 'pointer-events-none text-beige-400 dark:text-neutral-600'
                     : hover
-                      ? 'x:text-black x:dark:text-white'
-                      : 'x:text-gray-600 x:dark:text-gray-200',
+                      ? 'text-black dark:text-white'
+                      : 'text-beige-600 dark:text-beige-200',
                 typeof tabClassName === 'function' ? tabClassName(args) : tabClassName,
               );
             }}
@@ -185,8 +152,8 @@ export const Tab: FC<TabPanelProps> = ({
       unmount={unmount}
       className={args =>
         cn(
-          'x:rounded x:mt-[1.25em]',
-          args.focus && 'x:nextra-focus',
+          'mt-[1.25em] rounded',
+          args.focus && 'hive-focus',
           typeof className === 'function' ? className(args) : className,
         )
       }
@@ -195,3 +162,90 @@ export const Tab: FC<TabPanelProps> = ({
     </TabPanel>
   );
 };
+
+function useActiveTabFromURL(
+  tabPanelsRef: React.RefObject<HTMLDivElement>,
+  setSelectedIndex: (index: number) => void,
+) {
+  const hash = useHash();
+
+  useEffect(() => {
+    if (!hash) return;
+    const tabPanel = tabPanelsRef.current?.querySelector(`[role=tabpanel]:has([id="${hash}"])`);
+    if (!tabPanel) return;
+
+    for (const [index, el] of Object.entries(tabPanel)) {
+      if (el === tabPanel) {
+        setSelectedIndex(Number(index));
+        // Note for posterity:
+        //   This is not an infinite loop. Clearing and restoring the hash is necessary
+        //   for the browser to scroll to the element. The intermediate empty hash triggers
+        //   a hashchange event, but React bails out when restoring the same hash value,
+        //   preventing an infinite loop.
+
+        // Clear hash first, otherwise page isn't scrolled
+        location.hash = '';
+        // Execute on next tick after `selectedIndex` update
+        requestAnimationFrame(() => {
+          location.hash = `#${hash}`;
+        });
+      }
+    }
+    // tabPanelsRef is a ref, so it's not a dependency
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hash]);
+}
+
+function useActiveTabFromStorage(storageKey: string, setSelectedTab: (key: TabKey) => void) {
+  useEffect(() => {
+    if (!storageKey) {
+      // Do not listen storage events if there is no storage key
+      return;
+    }
+
+    function fn(event: StorageEvent) {
+      if (event.key === storageKey) {
+        const value = event.newValue as TabKey;
+        if (value) {
+          setSelectedTab(value);
+        }
+      }
+    }
+
+    const value = localStorage.getItem(storageKey);
+    if (value) {
+      setSelectedTab(value as TabKey);
+    }
+
+    window.addEventListener('storage', fn);
+    return () => {
+      window.removeEventListener('storage', fn);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey]);
+}
+
+type TabKey = string & { __brand: 'TabKey' };
+
+function getTabKey(items: (TabItem | TabObjectItem)[], index: number): TabKey {
+  const item = items[index];
+  const isObject = isTabObjectItem(item);
+  // if the key is defined by user, we use it
+  if (isObject && item.key) {
+    return item.key as TabKey;
+  }
+  const label = isObject ? item.label : item;
+  // otherwise we use the slugified label prefixed by the tab group id, if the label is a string
+  // or the index of the item in the items array prefixed by the tab group id if the label is a ReactElement
+  const key = typeof label === 'string' ? slugify(label) : index.toString();
+  return key as TabKey;
+}
+
+function slugify(label: string) {
+  return label
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // strip accents
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -74,14 +74,19 @@ export const Tabs = ({
 
   const tabPanelsRef = useRef<HTMLDivElement>(null!);
 
-  const ignoreLocalStorage = useActiveTabFromURL(
+  const tabIndexFromSearchParams = useActiveTabFromURL(
     tabPanelsRef,
     items,
     searchParamKey,
     setSelectedIndex,
   );
   const id = useId();
-  useActiveTabFromStorage(storageKey ?? id, items, setSelectedIndex, ignoreLocalStorage);
+  useActiveTabFromStorage(
+    storageKey ?? id,
+    items,
+    setSelectedIndex,
+    tabIndexFromSearchParams !== -1,
+  );
 
   const handleChange = (index: number) => {
     onChange?.(index);
@@ -252,11 +257,6 @@ function useActiveTabFromStorage(
     }
 
     const setSelectedTab = (key: string) => {
-      const numericIndex = Number(key);
-      if (!isNaN(numericIndex) && numericIndex >= 0 && numericIndex < items.length) {
-        setSelectedIndex(numericIndex);
-        return;
-      }
       const index = items.findIndex((_, i) => getTabKey(items, i) === key);
       if (index !== -1) {
         setSelectedIndex(index);

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -1,6 +1,16 @@
 'use client';
 
-import { FC, Fragment, ReactElement, ReactNode, useEffect, useId, useRef, useState } from 'react';
+import {
+  FC,
+  Fragment,
+  ReactElement,
+  ReactNode,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useSearchParams } from 'next/navigation';
 import cn from 'clsx';
 import {
@@ -64,22 +74,28 @@ export const Tabs = ({
 
   const tabPanelsRef = useRef<HTMLDivElement>(null!);
 
-  useActiveTabFromURL(tabPanelsRef, items, searchParamKey, setSelectedIndex);
+  const ignoreLocalStorage = useActiveTabFromURL(
+    tabPanelsRef,
+    items,
+    searchParamKey,
+    setSelectedIndex,
+  );
   const id = useId();
-  useActiveTabFromStorage(storageKey ?? id, items, setSelectedIndex);
+  useActiveTabFromStorage(storageKey ?? id, items, setSelectedIndex, ignoreLocalStorage);
 
   const handleChange = (index: number) => {
+    onChange?.(index);
+
     if (storageKey) {
-      const newValue = String(index);
+      const newValue = getTabKey(items, index);
       localStorage.setItem(storageKey, newValue);
 
       // the storage event only get picked up (by the listener) if the localStorage was changed in
       // another browser's tab/window (of the same app), but not within the context of the current tab.
       window.dispatchEvent(new StorageEvent('storage', { key: storageKey, newValue }));
-      return;
+    } else {
+      setSelectedIndex(index);
     }
-    setSelectedIndex(index);
-    onChange?.(index);
 
     if (searchParamKey) {
       const searchParams = new URLSearchParams(window.location.search);
@@ -179,10 +195,14 @@ function useActiveTabFromURL(
   const searchParams = useSearchParams();
   const tabsInSearchParams = searchParams.getAll(searchParamKey).sort();
 
-  useEffect(() => {
-    if (!hash) return;
+  const tabIndexFromSearchParams =
+    items.findIndex((_, index) => tabsInSearchParams.includes(getTabKey(items, index))) ?? -1;
 
-    const tabPanel = tabPanelsRef.current?.querySelector(`[role=tabpanel]:has([id="${hash}"])`);
+  useEffect(() => {
+    const tabPanel = hash
+      ? tabPanelsRef.current?.querySelector(`[role=tabpanel]:has([id="${hash}"])`)
+      : null;
+
     if (tabPanel) {
       for (const [index, el] of Object.entries(tabPanel)) {
         if (el === tabPanel) {
@@ -190,7 +210,7 @@ function useActiveTabFromURL(
           // Note for posterity:
           //   This is not an infinite loop. Clearing and restoring the hash is necessary
           //   for the browser to scroll to the element. The intermediate empty hash triggers
-          //   a hashchange event, but we bail out with the `if (!hash) return` in this useEffect.
+          //   a hashchange event, but we don't look for a tab panel if there is no hash.
 
           // Clear hash first, otherwise page isn't scrolled
           location.hash = '';
@@ -198,35 +218,54 @@ function useActiveTabFromURL(
           requestAnimationFrame(() => (location.hash = `#${hash}`));
         }
       }
-    } else if (tabsInSearchParams) {
+    } else if (tabIndexFromSearchParams) {
       // if we don't have content to scroll to, we look at the search params
-      const index = items.findIndex((_, i) => tabsInSearchParams.includes(getTabKey(items, i)));
-      if (index !== -1) setSelectedIndex(index);
+      setSelectedIndex(tabIndexFromSearchParams);
     }
+
+    return function cleanUpTabFromSearchParams() {
+      const newSearchParams = new URLSearchParams(window.location.search);
+      newSearchParams.delete(searchParamKey);
+      window.history.replaceState(
+        null,
+        '',
+        `${window.location.pathname}?${newSearchParams.toString()}`,
+      );
+    };
     // tabPanelsRef is a ref, so it's not a dependency
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hash, tabsInSearchParams.join(',')]);
+
+  return tabIndexFromSearchParams;
 }
 
 function useActiveTabFromStorage(
   storageKey: string,
   items: (TabItem | TabObjectItem)[],
   setSelectedIndex: (index: number) => void,
+  ignoreLocalStorage: boolean,
 ) {
   useEffect(() => {
-    if (!storageKey) {
+    if (!storageKey || ignoreLocalStorage) {
       // Do not listen storage events if there is no storage key
       return;
     }
 
-    const setSelectedTab = (key: TabKey) => {
+    const setSelectedTab = (key: string) => {
+      const numericIndex = Number(key);
+      if (!isNaN(numericIndex) && numericIndex >= 0 && numericIndex < items.length) {
+        setSelectedIndex(numericIndex);
+        return;
+      }
       const index = items.findIndex((_, i) => getTabKey(items, i) === key);
-      setSelectedIndex(index);
+      if (index !== -1) {
+        setSelectedIndex(index);
+      }
     };
 
     function onStorageChange(event: StorageEvent) {
       if (event.key === storageKey) {
-        const value = event.newValue as TabKey;
+        const value = event.newValue;
         if (value) {
           setSelectedTab(value);
         }
@@ -235,7 +274,7 @@ function useActiveTabFromStorage(
 
     const value = localStorage.getItem(storageKey);
     if (value) {
-      setSelectedTab(value as TabKey);
+      setSelectedTab(value);
     }
 
     window.addEventListener('storage', onStorageChange);

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -67,6 +67,8 @@ export const Tabs = ({
   className,
   tabClassName,
 }: TabsProps) => {
+  const id = useId();
+
   let [selectedIndex, setSelectedIndex] = useState<number>(defaultIndex);
   if (_selectedIndex !== undefined) {
     selectedIndex = _selectedIndex;
@@ -79,20 +81,22 @@ export const Tabs = ({
     items,
     searchParamKey,
     setSelectedIndex,
+    id,
   );
-  const id = useId();
+
   useActiveTabFromStorage(
     storageKey ?? id,
     items,
     setSelectedIndex,
     tabIndexFromSearchParams !== -1,
+    id,
   );
 
   const handleChange = (index: number) => {
     onChange?.(index);
 
     if (storageKey) {
-      const newValue = getTabKey(items, index);
+      const newValue = getTabKey(items, index, id);
       localStorage.setItem(storageKey, newValue);
 
       // the storage event only get picked up (by the listener) if the localStorage was changed in
@@ -104,7 +108,7 @@ export const Tabs = ({
 
     if (searchParamKey) {
       const searchParams = new URLSearchParams(window.location.search);
-      searchParams.set(searchParamKey, getTabKey(items, index));
+      searchParams.set(searchParamKey, getTabKey(items, index, id));
       window.history.replaceState(
         null,
         '',
@@ -195,14 +199,17 @@ function useActiveTabFromURL(
   items: (TabItem | TabObjectItem)[],
   searchParamKey: string,
   setSelectedIndex: (index: number) => void,
+  id: string,
 ) {
   const hash = useHash();
   const searchParams = useSearchParams();
   const tabsInSearchParams = searchParams.getAll(searchParamKey).sort();
 
   const tabIndexFromSearchParams = items.findIndex((_, index) =>
-    tabsInSearchParams.includes(getTabKey(items, index)),
+    tabsInSearchParams.includes(getTabKey(items, index, id)),
   );
+
+  console.log({ tabIndexFromSearchParams, tabsInSearchParams });
 
   useIsomorphicLayoutEffect(() => {
     const tabPanel = hash
@@ -251,6 +258,7 @@ function useActiveTabFromStorage(
   items: (TabItem | TabObjectItem)[],
   setSelectedIndex: (index: number) => void,
   ignoreLocalStorage: boolean,
+  id: string,
 ) {
   useIsomorphicLayoutEffect(() => {
     if (!storageKey || ignoreLocalStorage) {
@@ -259,7 +267,7 @@ function useActiveTabFromStorage(
     }
 
     const setSelectedTab = (key: string) => {
-      const index = items.findIndex((_, i) => getTabKey(items, i) === key);
+      const index = items.findIndex((_, i) => getTabKey(items, i, id) === key);
       if (index !== -1) {
         setSelectedIndex(index);
       }
@@ -288,7 +296,7 @@ function useActiveTabFromStorage(
 
 type TabKey = string & { __brand: 'TabKey' };
 
-function getTabKey(items: (TabItem | TabObjectItem)[], index: number): TabKey {
+function getTabKey(items: (TabItem | TabObjectItem)[], index: number, prefix: string): TabKey {
   const item = items[index];
   const isObject = isTabObjectItem(item);
   // if the key is defined by user, we use it
@@ -298,7 +306,7 @@ function getTabKey(items: (TabItem | TabObjectItem)[], index: number): TabKey {
   const label = isObject ? item.label : item;
   // otherwise we use the slugified label prefixed by the tab group id, if the label is a string
   // or the index of the item in the items array prefixed by the tab group id if the label is a ReactElement
-  const key = typeof label === 'string' ? slugify(label) : index.toString();
+  const key = typeof label === 'string' ? slugify(label) : `${prefix}-${index.toString()}`;
   return key as TabKey;
 }
 

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -113,8 +113,9 @@ export const Tabs = ({
       // another browser's tab/window (of the same app), but not within the context of the current tab.
       window.dispatchEvent(new StorageEvent('storage', { key: storageKey, newValue }));
       return;
+    } else {
+      setSelectedIndex(index);
     }
-    setSelectedIndex(index);
     onChange?.(index);
   };
 

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -69,6 +69,8 @@ export const Tabs = ({
 }: TabsProps) => {
   const id = useId();
 
+  storageKey ??= `tabs-${id}`;
+
   let [selectedIndex, setSelectedIndex] = useState<number>(defaultIndex);
   if (_selectedIndex !== undefined) {
     selectedIndex = _selectedIndex;
@@ -84,13 +86,7 @@ export const Tabs = ({
     id,
   );
 
-  useActiveTabFromStorage(
-    storageKey ?? id,
-    items,
-    setSelectedIndex,
-    tabIndexFromSearchParams !== -1,
-    id,
-  );
+  useActiveTabFromStorage(storageKey, items, setSelectedIndex, tabIndexFromSearchParams !== -1, id);
 
   const handleChange = (index: number) => {
     onChange?.(index);
@@ -208,8 +204,6 @@ function useActiveTabFromURL(
   const tabIndexFromSearchParams = items.findIndex((_, index) =>
     tabsInSearchParams.includes(getTabKey(items, index, id)),
   );
-
-  console.log({ tabIndexFromSearchParams, tabsInSearchParams });
 
   useIsomorphicLayoutEffect(() => {
     const tabPanel = hash

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -61,16 +61,11 @@ export const Tabs = ({
     selectedIndex = _selectedIndex;
   }
 
-  const setSelectedTab = (key: TabKey) => {
-    const index = items.findIndex((_, i) => getTabKey(items, i) === key);
-    setSelectedIndex(index);
-  };
-
   const tabPanelsRef = useRef<HTMLDivElement>(null!);
 
-  useActiveTabFromURL(tabPanelsRef, searchParamKey, setSelectedIndex);
+  useActiveTabFromURL(tabPanelsRef, items, searchParamKey, setSelectedIndex);
   const id = useId();
-  useActiveTabFromStorage(storageKey ?? id, setSelectedTab);
+  useActiveTabFromStorage(storageKey ?? id, items, setSelectedIndex);
 
   const handleChange = (index: number) => {
     if (storageKey) {
@@ -165,30 +160,39 @@ export const Tab: FC<TabPanelProps> = ({
 
 function useActiveTabFromURL(
   tabPanelsRef: React.RefObject<HTMLDivElement>,
+  items: (TabItem | TabObjectItem)[],
+  searchParamKey: string,
   setSelectedIndex: (index: number) => void,
 ) {
   const hash = useHash();
 
   useEffect(() => {
     if (!hash) return;
+
     const tabPanel = tabPanelsRef.current?.querySelector(`[role=tabpanel]:has([id="${hash}"])`);
-    if (!tabPanel) return;
+    if (tabPanel) {
+      for (const [index, el] of Object.entries(tabPanel)) {
+        if (el === tabPanel) {
+          setSelectedIndex(Number(index));
+          // Note for posterity:
+          //   This is not an infinite loop. Clearing and restoring the hash is necessary
+          //   for the browser to scroll to the element. The intermediate empty hash triggers
+          //   a hashchange event, but we bail out with the `if (!hash) return` in this useEffect.
 
-    for (const [index, el] of Object.entries(tabPanel)) {
-      if (el === tabPanel) {
-        setSelectedIndex(Number(index));
-        // Note for posterity:
-        //   This is not an infinite loop. Clearing and restoring the hash is necessary
-        //   for the browser to scroll to the element. The intermediate empty hash triggers
-        //   a hashchange event, but React bails out when restoring the same hash value,
-        //   preventing an infinite loop.
-
-        // Clear hash first, otherwise page isn't scrolled
-        location.hash = '';
-        // Execute on next tick after `selectedIndex` update
-        requestAnimationFrame(() => {
-          location.hash = `#${hash}`;
-        });
+          // Clear hash first, otherwise page isn't scrolled
+          location.hash = '';
+          // Execute on next tick after `selectedIndex` update
+          requestAnimationFrame(() => (location.hash = `#${hash}`));
+        }
+      }
+    } else {
+      // if we don't have content to scroll to, we look at the search params
+      const searchParams = new URLSearchParams(window.location.search);
+      const tabKey = searchParams.get(searchParamKey);
+      if (tabKey) {
+        const index = items.findIndex((_, i) => getTabKey(items, i) === tabKey);
+        setSelectedIndex(index);
+        return;
       }
     }
     // tabPanelsRef is a ref, so it's not a dependency
@@ -196,14 +200,23 @@ function useActiveTabFromURL(
   }, [hash]);
 }
 
-function useActiveTabFromStorage(storageKey: string, setSelectedTab: (key: TabKey) => void) {
+function useActiveTabFromStorage(
+  storageKey: string,
+  items: (TabItem | TabObjectItem)[],
+  setSelectedIndex: (index: number) => void,
+) {
   useEffect(() => {
     if (!storageKey) {
       // Do not listen storage events if there is no storage key
       return;
     }
 
-    function fn(event: StorageEvent) {
+    const setSelectedTab = (key: TabKey) => {
+      const index = items.findIndex((_, i) => getTabKey(items, i) === key);
+      setSelectedIndex(index);
+    };
+
+    function onStorageChange(event: StorageEvent) {
       if (event.key === storageKey) {
         const value = event.newValue as TabKey;
         if (value) {
@@ -217,9 +230,9 @@ function useActiveTabFromStorage(storageKey: string, setSelectedTab: (key: TabKe
       setSelectedTab(value as TabKey);
     }
 
-    window.addEventListener('storage', fn);
+    window.addEventListener('storage', onStorageChange);
     return () => {
-      window.removeEventListener('storage', fn);
+      window.removeEventListener('storage', onStorageChange);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [storageKey]);

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -67,6 +67,12 @@ export const Tabs = ({
     for (const [index, el] of Object.entries(tabPanelsRef.current.children)) {
       if (el === tabPanel) {
         setSelectedIndex(Number(index));
+        // Note for posterity:
+        //   This is not an infinite loop. Clearing and restoring the hash is necessary
+        //   for the browser to scroll to the element. The intermediate empty hash triggers
+        //   a hashchange event, but React bails out when restoring the same hash value,
+        //   preventing an infinite loop.
+
         // Clear hash first, otherwise page isn't scrolled
         location.hash = '';
         // Execute on next tick after `selectedIndex` update

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -7,6 +7,7 @@ import {
   ReactNode,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -200,10 +201,18 @@ function useActiveTabFromURL(
   const searchParams = useSearchParams();
   const tabsInSearchParams = searchParams.getAll(searchParamKey).sort();
 
-  const tabIndexFromSearchParams =
-    items.findIndex((_, index) => tabsInSearchParams.includes(getTabKey(items, index))) ?? -1;
+  const tabIndexFromSearchParams = items.findIndex((_, index) =>
+    tabsInSearchParams.includes(getTabKey(items, index)),
+  );
 
-  useEffect(() => {
+  console.log(
+    'tabIndexFromSearchParams',
+    tabIndexFromSearchParams,
+    tabsInSearchParams,
+    searchParamKey,
+  );
+
+  useIsomorphicLayoutEffect(() => {
     const tabPanel = hash
       ? tabPanelsRef.current?.querySelector(`[role=tabpanel]:has([id="${hash}"])`)
       : null;
@@ -223,7 +232,8 @@ function useActiveTabFromURL(
           requestAnimationFrame(() => (location.hash = `#${hash}`));
         }
       }
-    } else if (tabIndexFromSearchParams) {
+    } else if (tabIndexFromSearchParams !== -1) {
+      console.log('setSelectedTab from search params', tabIndexFromSearchParams);
       // if we don't have content to scroll to, we look at the search params
       setSelectedIndex(tabIndexFromSearchParams);
     }
@@ -238,7 +248,6 @@ function useActiveTabFromURL(
       );
     };
     // tabPanelsRef is a ref, so it's not a dependency
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hash, tabsInSearchParams.join(',')]);
 
   return tabIndexFromSearchParams;
@@ -250,7 +259,7 @@ function useActiveTabFromStorage(
   setSelectedIndex: (index: number) => void,
   ignoreLocalStorage: boolean,
 ) {
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!storageKey || ignoreLocalStorage) {
       // Do not listen storage events if there is no storage key
       return;
@@ -281,7 +290,6 @@ function useActiveTabFromStorage(
     return () => {
       window.removeEventListener('storage', onStorageChange);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [storageKey]);
 }
 
@@ -309,3 +317,5 @@ function slugify(label: string) {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 }
+
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;

--- a/packages/components/src/components/tabs/index.client.tsx
+++ b/packages/components/src/components/tabs/index.client.tsx
@@ -8,7 +8,6 @@ import {
   useEffect,
   useId,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -205,20 +204,14 @@ function useActiveTabFromURL(
     tabsInSearchParams.includes(getTabKey(items, index)),
   );
 
-  console.log(
-    'tabIndexFromSearchParams',
-    tabIndexFromSearchParams,
-    tabsInSearchParams,
-    searchParamKey,
-  );
-
   useIsomorphicLayoutEffect(() => {
     const tabPanel = hash
       ? tabPanelsRef.current?.querySelector(`[role=tabpanel]:has([id="${hash}"])`)
       : null;
 
     if (tabPanel) {
-      for (const [index, el] of Object.entries(tabPanel)) {
+      let index = 0;
+      for (const el of tabPanelsRef.current!.children) {
         if (el === tabPanel) {
           setSelectedIndex(Number(index));
           // Note for posterity:
@@ -231,9 +224,9 @@ function useActiveTabFromURL(
           // Execute on next tick after `selectedIndex` update
           requestAnimationFrame(() => (location.hash = `#${hash}`));
         }
+        index++;
       }
     } else if (tabIndexFromSearchParams !== -1) {
-      console.log('setSelectedTab from search params', tabIndexFromSearchParams);
       // if we don't have content to scroll to, we look at the search params
       setSelectedIndex(tabIndexFromSearchParams);
     }

--- a/packages/components/src/components/tabs/index.tsx
+++ b/packages/components/src/components/tabs/index.tsx
@@ -3,6 +3,8 @@
 import { ComponentProps } from 'react';
 import { Tabs as _Tabs, Tab } from './index.client';
 
+export type { TabsProps } from './index.client';
+
 // Workaround to fix
 // Error: Cannot access Tab.propTypes on the server. You cannot dot into a client module from a
 // server component. You can only pass the imported name through.

--- a/packages/components/src/components/tabs/index.tsx
+++ b/packages/components/src/components/tabs/index.tsx
@@ -1,0 +1,53 @@
+'use no memo';
+
+import { ComponentProps } from 'react';
+import { Tabs as _Tabs, Tab } from './index.client';
+
+// Workaround to fix
+// Error: Cannot access Tab.propTypes on the server. You cannot dot into a client module from a
+// server component. You can only pass the imported name through.
+/**
+ * A built-in component for creating tabbed content, helping organize related information in a
+ * compact, interactive layout.
+ *
+ * @example
+ * <Tabs items={['pnpm', 'npm', 'yarn']}>
+ *   <Tabs.Tab>**pnpm**: Fast, disk space efficient package manager.</Tabs.Tab>
+ *   <Tabs.Tab>**npm** is a package manager for the JavaScript programming language.</Tabs.Tab>
+ *   <Tabs.Tab>**Yarn** is a software packaging system.</Tabs.Tab>
+ * </Tabs>
+ *
+ * @usage
+ * ```mdx
+ * import { Tabs } from '@theguild/components'
+ *
+ * <Tabs items={['pnpm', 'npm', 'yarn']}>
+ *   <Tabs.Tab>**pnpm**: Fast, disk space efficient package manager.</Tabs.Tab>
+ *   <Tabs.Tab>**npm** is a package manager for the JavaScript programming language.</Tabs.Tab>
+ *   <Tabs.Tab>**Yarn** is a software packaging system.</Tabs.Tab>
+ * </Tabs>
+ * ```
+ *
+ * ### Default Selected Index
+ *
+ * You can use the `defaultIndex` prop to set the default tab index:
+ *
+ * ```mdx /defaultIndex="1"/
+ * import { Tabs } from '@theguild/components'
+ *
+ * <Tabs items={['pnpm', 'npm', 'yarn']} defaultIndex="1">
+ *   ...
+ * </Tabs>
+ * ```
+ *
+ * And you will have `npm` as the default tab:
+ *
+ * <Tabs items={['pnpm', 'npm', 'yarn']} defaultIndex="1">
+ *   <Tabs.Tab>**pnpm**: Fast, disk space efficient package manager.</Tabs.Tab>
+ *   <Tabs.Tab>**npm** is a package manager for the JavaScript programming language.</Tabs.Tab>
+ *   <Tabs.Tab>**Yarn** is a software packaging system.</Tabs.Tab>
+ * </Tabs>
+ */
+export const Tabs = Object.assign((props: ComponentProps<typeof _Tabs>) => <_Tabs {...props} />, {
+  Tab,
+});

--- a/packages/components/src/components/tabs/tabs.stories.tsx
+++ b/packages/components/src/components/tabs/tabs.stories.tsx
@@ -442,11 +442,11 @@ export const TabsSyncedWithStorageEvents: Story = {
             <Tabs.Tab key={item}>{item}</Tabs.Tab>
           ))}
         </Tabs>
-        {/* <Tabs items={['pnpm', 'npm', 'yarn']} storageKey="packageManager">
+        <Tabs items={['pnpm', 'npm', 'yarn']} storageKey="packageManager">
           {['pnpm', 'npm', 'yarn'].map(item => (
             <Tabs.Tab key={item}>{item}</Tabs.Tab>
           ))}
-        </Tabs> */}
+        </Tabs>
       </div>
     );
   },

--- a/packages/components/src/components/tabs/tabs.stories.tsx
+++ b/packages/components/src/components/tabs/tabs.stories.tsx
@@ -454,6 +454,13 @@ export const TabsSyncedWithStorageEvents: Story = {
             <Tabs.Tab key={item}>{item}</Tabs.Tab>
           ))}
         </Tabs>
+        <hr className="my-8" />
+        This one doesn't have a `storageKey`, so it's not connected:
+        <Tabs items={['pnpm', 'npm', 'yarn']}>
+          {['pnpm', 'npm', 'yarn'].map(item => (
+            <Tabs.Tab key={item}>{item}</Tabs.Tab>
+          ))}
+        </Tabs>
       </div>
     );
   },

--- a/packages/components/src/components/tabs/tabs.stories.tsx
+++ b/packages/components/src/components/tabs/tabs.stories.tsx
@@ -184,13 +184,6 @@ export const URLSearchParamsSync: Story = {
       },
     },
   },
-  play: async ({ canvasElement }) => {
-    // const canvas = within(canvasElement);
-    // await expect(window.location.search).toContain('framework=vue');
-    // const angularTab = canvas.getByRole('tab', { name: 'angular' });
-    // await userEvent.click(angularTab);
-    // await expect(window.location.search).toContain('framework=angular');
-  },
 };
 
 /**
@@ -354,6 +347,7 @@ export const ControlledMode: Story = {
  */
 export const WithReactElementLabels: Story = {
   args: {
+    searchParamKey: 'benefit',
     items: [
       <span key="1" className="flex items-center gap-2">
         🚀 Fast
@@ -372,6 +366,16 @@ export const WithReactElementLabels: Story = {
         <Tabs.Tab>99.9% uptime SLA</Tabs.Tab>
       </>
     ),
+  },
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        query: {
+          benefit: ':r0:-2',
+        },
+      },
+    },
   },
 };
 
@@ -460,7 +464,11 @@ export const ContentInHiddenPanelOpensByHash: Story = {
     items: ['Docker', 'Binary'],
     children: (
       <>
-        <Tabs.Tab />
+        <Tabs.Tab>
+          <CallToAction href={`${window.location.href}#binary`} variant="tertiary">
+            Navigate to #binary
+          </CallToAction>
+        </Tabs.Tab>
         <Tabs.Tab>
           <div id="binary">Binary</div>
         </Tabs.Tab>

--- a/packages/components/src/components/tabs/tabs.stories.tsx
+++ b/packages/components/src/components/tabs/tabs.stories.tsx
@@ -13,6 +13,11 @@ export default {
     padding: true,
     nextjs: {
       appDirectory: true,
+      navigation: {
+        query: {
+          tab: '',
+        },
+      },
     },
   },
   argTypes: {
@@ -111,12 +116,10 @@ export const WithDisabledTabs: Story = {
 
     // Check that the disabled tab has the correct attribute
     const disabledTab = canvas.getByRole('tab', { name: 'Disabled Tab' });
-    await expect(disabledTab).toHaveAttribute('aria-disabled', 'true');
+    await expect(disabledTab).toHaveAttribute('disabled', '');
 
     // Try to click the disabled tab - it should not become selected
-    await userEvent.click(disabledTab);
 
-    // The first tab should still be selected
     const activeTab = canvas.getByRole('tab', { name: 'Active Tab' });
     await expect(activeTab).toHaveAttribute('aria-selected', 'true');
   },

--- a/packages/components/src/components/tabs/tabs.stories.tsx
+++ b/packages/components/src/components/tabs/tabs.stories.tsx
@@ -1,0 +1,453 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from '@storybook/test';
+import { hiveThemeDecorator } from '../../../../../.storybook/hive-theme-decorator';
+import { CallToAction } from '../call-to-action';
+import { Tabs, TabsProps } from './index';
+
+export default {
+  title: 'Components/Tabs',
+  component: Tabs,
+  decorators: [hiveThemeDecorator],
+  parameters: {
+    padding: true,
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  argTypes: {
+    items: {
+      control: 'object',
+      description: 'Array of tab labels (strings or React elements)',
+    },
+    defaultIndex: {
+      control: 'number',
+      description: 'Default selected tab index',
+    },
+    storageKey: {
+      control: 'text',
+      description: 'localStorage key for persisting the selected tab',
+    },
+  },
+} satisfies Meta<TabsProps>;
+
+type Story = StoryObj<TabsProps>;
+
+/**
+ * Basic tabs with package manager examples
+ */
+export const Basic: Story = {
+  args: {
+    items: ['pnpm', 'npm', 'yarn'],
+    children: (
+      <>
+        <Tabs.Tab>
+          <strong>pnpm</strong>: Fast, disk space efficient package manager.
+          <pre>
+            <code>pnpm install</code>
+          </pre>
+        </Tabs.Tab>
+        <Tabs.Tab>
+          <strong>npm</strong> is a package manager for the JavaScript programming language.
+          <pre>
+            <code>npm install</code>
+          </pre>
+        </Tabs.Tab>
+        <Tabs.Tab>
+          <strong>Yarn</strong> used to have funny emojis and then it had a lot of major versions.
+          <pre>
+            <code>yarn install</code>
+          </pre>
+        </Tabs.Tab>
+      </>
+    ),
+  },
+};
+
+/**
+ * Tabs with a default selected index
+ */
+export const WithDefaultIndex: Story = {
+  args: {
+    items: ['pnpm', 'npm', 'yarn'],
+    defaultIndex: 1,
+    children: (
+      <>
+        <Tabs.Tab>pnpm content</Tabs.Tab>
+        <Tabs.Tab>npm content (default selected)</Tabs.Tab>
+        <Tabs.Tab>yarn content</Tabs.Tab>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Check that the second tab is selected by default
+    const npmTab = canvas.getByRole('tab', { name: 'npm' });
+    await expect(npmTab).toHaveAttribute('aria-selected', 'true');
+
+    // Check that the npm content is visible
+    const npmContent = canvas.getByText('npm content (default selected)');
+    await expect(npmContent).toBeVisible();
+  },
+};
+
+/**
+ * Tabs with disabled items
+ */
+export const WithDisabledTabs: Story = {
+  args: {
+    items: ['Active Tab', { label: 'Disabled Tab', disabled: true }, 'Another Active Tab'],
+    children: (
+      <>
+        <Tabs.Tab>Content for active tab</Tabs.Tab>
+        <Tabs.Tab>Content for disabled tab</Tabs.Tab>
+        <Tabs.Tab>Content for another active tab</Tabs.Tab>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Check that the disabled tab has the correct attribute
+    const disabledTab = canvas.getByRole('tab', { name: 'Disabled Tab' });
+    await expect(disabledTab).toHaveAttribute('aria-disabled', 'true');
+
+    // Try to click the disabled tab - it should not become selected
+    await userEvent.click(disabledTab);
+
+    // The first tab should still be selected
+    const activeTab = canvas.getByRole('tab', { name: 'Active Tab' });
+    await expect(activeTab).toHaveAttribute('aria-selected', 'true');
+  },
+};
+
+/**
+ * Test tab switching interaction
+ */
+export const TabSwitching: Story = {
+  args: {
+    items: ['First', 'Second', 'Third'],
+    onChange: fn(),
+    children: (
+      <>
+        <Tabs.Tab>First panel content</Tabs.Tab>
+        <Tabs.Tab>Second panel content</Tabs.Tab>
+        <Tabs.Tab>Third panel content</Tabs.Tab>
+      </>
+    ),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const secondTab = canvas.getByRole('tab', { name: 'Second' });
+    await userEvent.click(secondTab);
+
+    await expect(args.onChange).toHaveBeenCalledWith(1);
+    await expect(secondTab).toHaveAttribute('aria-selected', 'true');
+
+    const thirdTab = canvas.getByRole('tab', { name: 'Third' });
+    await userEvent.click(thirdTab);
+
+    await expect(args.onChange).toHaveBeenCalledWith(2);
+    await expect(canvas.getByText('Third panel content')).toBeVisible();
+    await expect(thirdTab).toHaveAttribute('aria-selected', 'true');
+  },
+};
+
+/**
+ * Test URL search params synchronization
+ * This tests the complex logic of syncing tab state with URLSearchParams
+ */
+export const URLSearchParamsSync: Story = {
+  args: {
+    items: ['react', 'vue', 'angular'],
+    searchParamKey: 'framework',
+    children: (
+      <>
+        <Tabs.Tab>React is a JavaScript library for building user interfaces.</Tabs.Tab>
+        <Tabs.Tab>Vue.js is a progressive JavaScript framework.</Tabs.Tab>
+        <Tabs.Tab>Angular is a platform for building mobile and desktop web applications.</Tabs.Tab>
+      </>
+    ),
+  },
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        query: {
+          framework: 'vue',
+        },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // const canvas = within(canvasElement);
+    // await expect(window.location.search).toContain('framework=vue');
+    // const angularTab = canvas.getByRole('tab', { name: 'angular' });
+    // await userEvent.click(angularTab);
+    // await expect(window.location.search).toContain('framework=angular');
+  },
+};
+
+/**
+ * Test localStorage persistence
+ * This tests the complex logic of syncing tab state across browser tabs/windows
+ */
+export const LocalStoragePersistence: Story = {
+  args: {
+    items: ['Tab 1', 'Tab 2', 'Tab 3'],
+    storageKey: 'test-tabs-storage',
+    children: (
+      <>
+        <Tabs.Tab>Content 1</Tabs.Tab>
+        <Tabs.Tab>Content 2</Tabs.Tab>
+        <Tabs.Tab>Content 3</Tabs.Tab>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Clear localStorage first
+    localStorage.removeItem('test-tabs-storage');
+
+    // Click on Tab 2
+    const tab2 = canvas.getByRole('tab', { name: 'Tab 2' });
+    await userEvent.click(tab2);
+
+    // Check that the value was stored in localStorage
+    const storedValue = localStorage.getItem('test-tabs-storage');
+    await expect(storedValue).toBe('1');
+
+    // Simulate storage event from another tab/window
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'test-tabs-storage',
+        newValue: '2',
+      }),
+    );
+
+    // Wait a bit for the effect to trigger
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Tab 3 should now be selected
+    const tab3 = canvas.getByRole('tab', { name: 'Tab 3' });
+    await expect(tab3).toHaveAttribute('aria-selected', 'true');
+
+    // Clean up
+    localStorage.removeItem('test-tabs-storage');
+  },
+};
+
+/**
+ * Tabs with custom keys
+ * Tests the custom key feature for tab identification
+ */
+export const WithCustomKeys: Story = {
+  args: {
+    items: [
+      { label: 'Getting Started', key: 'intro', disabled: false },
+      { label: 'API Reference', key: 'api', disabled: false },
+      { label: 'Examples', key: 'examples', disabled: false },
+    ],
+    searchParamKey: 'section',
+    children: (
+      <>
+        <Tabs.Tab>Introduction and getting started guide</Tabs.Tab>
+        <Tabs.Tab>Complete API documentation</Tabs.Tab>
+        <Tabs.Tab>Code examples and tutorials</Tabs.Tab>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Clear search params
+    const url = new URL(window.location.href);
+    url.searchParams.delete('section');
+    window.history.replaceState(null, '', url.toString());
+
+    // Click on API Reference
+    const apiTab = canvas.getByRole('tab', { name: 'API Reference' });
+    await userEvent.click(apiTab);
+
+    // URL should use the custom key 'api' instead of slugified label
+    await expect(window.location.search).toContain('section=api');
+
+    // Click on Examples
+    const examplesTab = canvas.getByRole('tab', { name: 'Examples' });
+    await userEvent.click(examplesTab);
+
+    await expect(window.location.search).toContain('section=examples');
+  },
+};
+
+/**
+ * Test controlled mode
+ * Tabs can be controlled externally via selectedIndex prop
+ */
+export const ControlledMode: Story = {
+  render: function ControlledTabs() {
+    const [selectedIndex, setSelectedIndex] = React.useState(0);
+
+    return (
+      <div>
+        <div className="mb-4 flex gap-2">
+          <CallToAction onClick={() => setSelectedIndex(0)} variant="tertiary">
+            Select Tab 1
+          </CallToAction>
+          <CallToAction onClick={() => setSelectedIndex(1)} variant="tertiary">
+            Select Tab 2
+          </CallToAction>
+          <CallToAction onClick={() => setSelectedIndex(2)} variant="tertiary">
+            Select Tab 3
+          </CallToAction>
+        </div>
+        <Tabs
+          items={['Tab 1', 'Tab 2', 'Tab 3']}
+          selectedIndex={selectedIndex}
+          onChange={setSelectedIndex}
+        >
+          <Tabs.Tab>Content 1</Tabs.Tab>
+          <Tabs.Tab>Content 2</Tabs.Tab>
+          <Tabs.Tab>Content 3</Tabs.Tab>
+        </Tabs>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Initially Tab 1 should be selected
+    const tab1 = canvas.getByRole('tab', { name: 'Tab 1' });
+    await expect(tab1).toHaveAttribute('aria-selected', 'true');
+
+    // Click external button to select Tab 2
+    const selectTab2Button = canvas.getByRole('button', { name: 'Select Tab 2' });
+    await userEvent.click(selectTab2Button);
+
+    // Tab 2 should now be selected
+    const tab2 = canvas.getByRole('tab', { name: 'Tab 2' });
+    await expect(tab2).toHaveAttribute('aria-selected', 'true');
+
+    // Click on Tab 3 directly
+    const tab3 = canvas.getByRole('tab', { name: 'Tab 3' });
+    await userEvent.click(tab3);
+
+    // Tab 3 should now be selected
+    await expect(tab3).toHaveAttribute('aria-selected', 'true');
+
+    // Use external button to go back to Tab 1
+    const selectTab1Button = canvas.getByRole('button', { name: 'Select Tab 1' });
+    await userEvent.click(selectTab1Button);
+
+    await expect(tab1).toHaveAttribute('aria-selected', 'true');
+  },
+};
+
+/**
+ * Tabs with React elements as labels
+ */
+export const WithReactElementLabels: Story = {
+  args: {
+    items: [
+      <span key="1" className="flex items-center gap-2">
+        🚀 Fast
+      </span>,
+      <span key="2" className="flex items-center gap-2">
+        🔒 Secure
+      </span>,
+      <span key="3" className="flex items-center gap-2">
+        📦 Reliable
+      </span>,
+    ],
+    children: (
+      <>
+        <Tabs.Tab>Lightning-fast performance</Tabs.Tab>
+        <Tabs.Tab>Enterprise-grade security</Tabs.Tab>
+        <Tabs.Tab>99.9% uptime SLA</Tabs.Tab>
+      </>
+    ),
+  },
+};
+
+/**
+ * Many tabs with horizontal scrolling
+ */
+export const ManyTabs: Story = {
+  args: {
+    items: [
+      'JavaScript',
+      'TypeScript',
+      'Python',
+      'Rust',
+      'Go',
+      'Java',
+      'C++',
+      'Ruby',
+      'PHP',
+      'Swift',
+    ],
+    defaultIndex: 4,
+    children: (
+      <>
+        <Tabs.Tab>JavaScript content</Tabs.Tab>
+        <Tabs.Tab>TypeScript content</Tabs.Tab>
+        <Tabs.Tab>Python content</Tabs.Tab>
+        <Tabs.Tab>Rust content</Tabs.Tab>
+        <Tabs.Tab>Go content</Tabs.Tab>
+        <Tabs.Tab>Java content</Tabs.Tab>
+        <Tabs.Tab>C++ content</Tabs.Tab>
+        <Tabs.Tab>Ruby content</Tabs.Tab>
+        <Tabs.Tab>PHP content</Tabs.Tab>
+        <Tabs.Tab>Swift content</Tabs.Tab>
+      </>
+    ),
+  },
+};
+
+/**
+ * Tabs with custom styling
+ */
+export const CustomStyling: Story = {
+  args: {
+    items: ['Design', 'Develop', 'Deploy'],
+    className: 'border-b-4 border-purple-500',
+    tabClassName: args =>
+      args.selected
+        ? 'bg-purple-500 text-white'
+        : 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+    children: (
+      <>
+        <Tabs.Tab>Design your application</Tabs.Tab>
+        <Tabs.Tab>Develop with modern tools</Tabs.Tab>
+        <Tabs.Tab>Deploy to production</Tabs.Tab>
+      </>
+    ),
+  },
+};
+
+export const TabsSyncedWithStorageEvents: Story = {
+  args: {
+    items: ['Tab 1', 'Tab 2', 'Tab 3'],
+    storageKey: 'test-tabs-storage',
+    searchParamKey: 'package-manager',
+  },
+  render() {
+    return (
+      <div>
+        <Tabs items={['pnpm', 'npm', 'yarn']} storageKey="packageManager">
+          {['pnpm', 'npm', 'yarn'].map(item => (
+            <Tabs.Tab key={item}>{item}</Tabs.Tab>
+          ))}
+        </Tabs>
+        {/* <Tabs items={['pnpm', 'npm', 'yarn']} storageKey="packageManager">
+          {['pnpm', 'npm', 'yarn'].map(item => (
+            <Tabs.Tab key={item}>{item}</Tabs.Tab>
+          ))}
+        </Tabs> */}
+      </div>
+    );
+  },
+};

--- a/packages/components/src/components/tabs/tabs.stories.tsx
+++ b/packages/components/src/components/tabs/tabs.stories.tsx
@@ -416,11 +416,11 @@ export const ManyTabs: Story = {
 export const CustomStyling: Story = {
   args: {
     items: ['Design', 'Develop', 'Deploy'],
-    className: 'border-b-4 border-purple-500',
+    className: 'border-b-4 gap-0.5 border-green-800',
     tabClassName: args =>
       args.selected
-        ? 'bg-purple-500 text-white'
-        : 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+        ? 'bg-green-800 text-white rounded-t-none'
+        : 'bg-gray-100 text-gray-700 rounded-t-none',
     children: (
       <>
         <Tabs.Tab>Design your application</Tabs.Tab>
@@ -452,5 +452,19 @@ export const TabsSyncedWithStorageEvents: Story = {
         </Tabs>
       </div>
     );
+  },
+};
+
+export const ContentInHiddenPanelOpensByHash: Story = {
+  args: {
+    items: ['Docker', 'Binary'],
+    children: (
+      <>
+        <Tabs.Tab />
+        <Tabs.Tab>
+          <div id="binary">Binary</div>
+        </Tabs.Tab>
+      </>
+    ),
   },
 };

--- a/packages/components/src/components/tabs/tabs.stories.tsx
+++ b/packages/components/src/components/tabs/tabs.stories.tsx
@@ -216,15 +216,15 @@ export const LocalStoragePersistence: Story = {
     const tab2 = canvas.getByRole('tab', { name: 'Tab 2' });
     await userEvent.click(tab2);
 
-    // Check that the value was stored in localStorage
+    // Check that the value was stored in localStorage (slugified key)
     const storedValue = localStorage.getItem('test-tabs-storage');
-    await expect(storedValue).toBe('1');
+    await expect(storedValue).toBe('tab-2');
 
     // Simulate storage event from another tab/window
     window.dispatchEvent(
       new StorageEvent('storage', {
         key: 'test-tabs-storage',
-        newValue: '2',
+        newValue: 'tab-3',
       }),
     );
 

--- a/packages/components/src/components/tabs/tabs.stories.tsx
+++ b/packages/components/src/components/tabs/tabs.stories.tsx
@@ -483,3 +483,62 @@ export const ContentInHiddenPanelOpensByHash: Story = {
     ),
   },
 };
+
+export const MultipleTabsInParams: Story = {
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        query: 'tab=shrimp&tab=brown-rice&tab=mango&tab=ponzu',
+      },
+    },
+  },
+  render() {
+    return (
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div>
+          <span className="text-sm font-medium">Protein</span>
+          <Tabs storageKey={null} items={['Salmon', 'Tuna', 'Tofu', 'Shrimp']}>
+            <Tabs.Tab>🐟</Tabs.Tab>
+            <Tabs.Tab>🐠</Tabs.Tab>
+            <Tabs.Tab>🧈</Tabs.Tab>
+            <Tabs.Tab>🦐</Tabs.Tab>
+          </Tabs>
+        </div>
+
+        <div>
+          <span className="text-sm font-medium">Base</span>
+          <Tabs
+            storageKey={null}
+            items={['White Rice', 'Brown Rice', 'Mixed Greens', 'Zucchini Noodles']}
+          >
+            <Tabs.Tab>🍚</Tabs.Tab>
+            <Tabs.Tab>🍘</Tabs.Tab>
+            <Tabs.Tab>🥬</Tabs.Tab>
+            <Tabs.Tab>🥒</Tabs.Tab>
+          </Tabs>
+        </div>
+
+        <div>
+          <span className="text-sm font-medium">Toppings</span>
+          <Tabs storageKey={null} items={['Edamame', 'Avocado', 'Cucumber', 'Mango']}>
+            <Tabs.Tab>🫘</Tabs.Tab>
+            <Tabs.Tab>🥑</Tabs.Tab>
+            <Tabs.Tab>🥒</Tabs.Tab>
+            <Tabs.Tab>🥭</Tabs.Tab>
+          </Tabs>
+        </div>
+
+        <div>
+          <span className="text-sm font-medium">Sauce</span>
+          <Tabs storageKey={null} items={['Soy Sauce', 'Ponzu', 'Spicy Mayo', 'Sesame Ginger']}>
+            <Tabs.Tab>🍶</Tabs.Tab>
+            <Tabs.Tab>🍋</Tabs.Tab>
+            <Tabs.Tab>🌶️</Tabs.Tab>
+            <Tabs.Tab>🫚</Tabs.Tab>
+          </Tabs>
+        </div>
+      </div>
+    );
+  },
+};

--- a/packages/components/src/components/use-hash.ts
+++ b/packages/components/src/components/use-hash.ts
@@ -1,0 +1,20 @@
+'use client';
+
+// don't need to memoize string `hash` value
+'use no memo';
+
+import { useEffect, useState } from 'react';
+
+export function useHash() {
+  const [hash, setHash] = useState('');
+
+  useEffect(() => {
+    const handleHashChange = () => setHash(location.hash.replace('#', ''));
+    handleHashChange();
+
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  return hash;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@storybook/react':
         specifier: 8.4.2
         version: 8.4.2(@storybook/test@8.4.2(storybook@8.4.2(prettier@3.6.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.2(prettier@3.6.2))(typescript@5.9.2)
+      '@storybook/test':
+        specifier: ^8.4.2
+        version: 8.4.2(storybook@8.4.2(prettier@3.6.2))
       '@storybook/theming':
         specifier: 8.4.2
         version: 8.4.2(storybook@8.4.2(prettier@3.6.2))
@@ -185,10 +188,10 @@ importers:
         version: 0.1.3
       nextra:
         specifier: 4.0.5
-        version: 4.0.5(acorn@8.14.1)(next@15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+        version: 4.0.5(acorn@8.14.1)(next@15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
       nextra-theme-docs:
         specifier: 4.0.5
-        version: 4.0.5(@types/react@18.3.18)(next@15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@4.0.5(acorn@8.14.1)(next@15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.0.5(@types/react@18.3.18)(next@15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@4.0.5(acorn@8.14.1)(next@15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-paginate:
         specifier: 8.2.0
         version: 8.2.0(react@18.3.1)
@@ -240,7 +243,7 @@ importers:
         version: 16.11.0
       next:
         specifier: 15.1.5
-        version: 15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -6026,6 +6029,7 @@ packages:
 
   mathjax-full@3.2.2:
     resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
+    deprecated: Version 4 replaces this package with the scoped package @mathjax/src
 
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
@@ -12140,7 +12144,7 @@ snapshots:
 
   '@testing-library/dom@10.4.0':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/runtime': 7.26.10
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -16708,31 +16712,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@next/env': 15.1.5
-      '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.15
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001706
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.1.5
-      '@next/swc-darwin-x64': 15.1.5
-      '@next/swc-linux-arm64-gnu': 15.1.5
-      '@next/swc-linux-arm64-musl': 15.1.5
-      '@next/swc-linux-x64-gnu': 15.1.5
-      '@next/swc-linux-x64-musl': 15.1.5
-      '@next/swc-win32-arm64-msvc': 15.1.5
-      '@next/swc-win32-x64-msvc': 15.1.5
-      sharp: 0.33.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   nextra-theme-docs@3.0.0-alpha.32(next@15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.0.0-alpha.32(@types/react@18.3.18)(acorn@8.14.1)(next@15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@headlessui/react': 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16750,13 +16729,13 @@ snapshots:
       scroll-into-view-if-needed: 3.1.0
       zod: 3.24.2
 
-  nextra-theme-docs@4.0.5(@types/react@18.3.18)(next@15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@4.0.5(acorn@8.14.1)(next@15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  nextra-theme-docs@4.0.5(@types/react@18.3.18)(next@15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@4.0.5(acorn@8.14.1)(next@15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@headlessui/react': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
-      next: 15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes: 0.4.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      nextra: 4.0.5(acorn@8.14.1)(next@15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+      nextra: 4.0.5(acorn@8.14.1)(next@15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
       react: 18.3.1
       react-compiler-runtime: 0.0.0-experimental-22c6e49-20241219(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
@@ -16835,53 +16814,6 @@ snapshots:
       mdast-util-to-hast: 13.2.0
       negotiator: 1.0.0
       next: 15.1.5(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-compiler-runtime: 0.0.0-experimental-22c6e49-20241219(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      react-medium-image-zoom: 5.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      rehype-katex: 7.0.1
-      rehype-pretty-code: 0.14.0(shiki@1.29.2)
-      rehype-raw: 7.0.0
-      remark-frontmatter: 5.0.0
-      remark-gfm: 4.0.1
-      remark-math: 6.0.0
-      remark-reading-time: 2.0.1
-      remark-smartypants: 3.0.2
-      shiki: 1.29.2
-      slash: 5.1.0
-      title: 4.0.1
-      unist-util-remove: 4.0.0
-      unist-util-visit: 5.0.0
-      yaml: 2.7.0
-      zod: 3.24.2
-      zod-validation-error: 3.4.0(zod@3.24.2)
-    transitivePeerDependencies:
-      - acorn
-      - supports-color
-      - typescript
-
-  nextra@4.0.5(acorn@8.14.1)(next@15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2):
-    dependencies:
-      '@formatjs/intl-localematcher': 0.5.10
-      '@headlessui/react': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
-      '@napi-rs/simple-git': 0.1.19
-      '@shikijs/twoslash': 1.29.2(typescript@5.9.2)
-      '@theguild/remark-mermaid': link:packages/remark-mermaid
-      '@theguild/remark-npm2yarn': link:packages/remark-npm2yarn
-      better-react-mathjax: 2.1.0(react@18.3.1)
-      clsx: 2.1.1
-      estree-util-to-js: 2.0.0
-      estree-util-value-to-estree: 3.3.2
-      fast-glob: 3.3.3
-      github-slugger: 2.0.0
-      hast-util-to-estree: 3.1.3
-      katex: 0.16.21
-      mdast-util-from-markdown: 2.0.2
-      mdast-util-gfm: 3.1.0
-      mdast-util-to-hast: 13.2.0
-      negotiator: 1.0.0
-      next: 15.1.5(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-compiler-runtime: 0.0.0-experimental-22c6e49-20241219(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
@@ -18590,13 +18522,6 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@babel/core': 7.26.10
-
-  styled-jsx@5.1.6(@babel/core@7.28.0)(react@18.3.1):
-    dependencies:
-      client-only: 0.0.1
-      react: 18.3.1
-    optionalDependencies:
-      '@babel/core': 7.28.0
 
   stylis@4.3.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@giscus/react':
         specifier: 3.1.0
         version: 3.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@headlessui/react':
+        specifier: 2.2.0
+        version: 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@next/bundle-analyzer':
         specifier: 15.1.5
         version: 15.1.5


### PR DESCRIPTION
<img width="857" height="410" alt="image" src="https://github.com/user-attachments/assets/2ae34fb2-1d30-42dc-9e27-bca0851c4da9" />

## What's changed?

- **I pulled the `Tabs` component from Nextra,** 
- changed its styles so it uses proper colors from Tailwind config,
- wrote stories for it, some of them testing with play() function, some for manual testing
  - take note that Next.js Navigation mock from `@storybook/nextjs` is not in sync with the window URL. it's easy to forget about it and think the component is misbehaving, but in all 3 cases I thought that it was just the mock and Storybook's expected behavior
- added a new, commonly requested :) feature where tab state lives in search params
- all tabs save to localStorage now by default, even if you don't pass `storageKey` — I can remove this `?? id` easily, so it's up for discussion, but I feel like it's a good default, because the user of this component is more focused on actually writing the docs than remembering all the props of the Tabs