### PR TITLE
fix(remark-mermaid): Restrict MutationObserver to theme attributes to prevent diagram disappearing

### DIFF
--- a/packages/remark-mermaid/src/mermaid.tsx
+++ b/packages/remark-mermaid/src/mermaid.tsx
@@ -38,7 +38,7 @@ export function Mermaid({ chart }: { chart: string }): ReactElement {
     }
     const htmlElement = document.documentElement;
     const observer = new MutationObserver(renderChart);
-    observer.observe(htmlElement, { attributes: true });
+    observer.observe(htmlElement, { attributes: true, attributeFilter: ['class', 'data-theme'] });
     renderChart();
 
     return () => {


### PR DESCRIPTION
## Problem

Flowchart SVGs disappear when the language dropdown is opened.
Related issue: [toss/suspensive#1884](https://github.com/toss/suspensive/issues/1884)

When a Headless UI-based dropdown (e.g. nextra's `LocaleSwitch`) opens, it activates a scroll-lock that sets `document.documentElement.style.overflow = "hidden"`.

The `MutationObserver` in the `Mermaid` component observes all attribute changes on `<html>`, so it fires on this `style` mutation and calls `renderChart()` concurrently with an already in-progress render.

Inside `mermaid.render()`, the container is always cleared first

```js
svgContainingElement.innerHTML = "";
```

When two renders race, the second call wipes the DOM elements that the first render created. The first render then hits a null reference, throws an error that is silently caught, and setSvg() is never called leaving the diagram permanently blank.

## Bug Trace
1. LocaleSwitch clicked -> Headless UI Listbox opens (modal: true by default)
2. useScrollLock sets document.documentElement.style.overflow = "hidden"
3. MutationObserver fires on style change -> renderChart() called mid-render
4. mermaid.render() clears container -> concurrent render hits null reference
5. Error is silently caught -> setSvg() never called -> diagram stays blank

## Fix
Add `attributeFilter: ['class', 'data-theme']` so the observer only reacts to attributes that actually signal a theme change, ignoring unrelated mutations like style.overflow.

```js
// as-is
// observer.observe(htmlElement, { attributes: true });

// to-be
observer.observe(htmlElement, { attributes: true, attributeFilter: ['class', 'data-theme'] });
```

Applied this patch locally to [toss/suspensive](https://github.com/toss/suspensive) and confirmed that flowcharts persist correctly when the LocaleSwitch dropdown is opened and closed, resolving [toss/suspensive#1884](https://github.com/toss/suspensive/issues/1884).

https://github.com/user-attachments/assets/89f5ef53-236f-445f-823a-3b70970a7ac7


