### PR TITLE
chore(remark-mermaid): add changeset for MutationObserver fix (#2102)

### DIFF
--- a/.changeset/clean-carrots-knock.md
+++ b/.changeset/clean-carrots-knock.md
@@ -1,0 +1,5 @@
+---
+'@theguild/remark-mermaid': patch
+---
+
+Restrict Mermaid's MutationObserver to theme attributes to prevent diagrams disappearing


### PR DESCRIPTION
Adds the missing changeset for #2102 (Mermaid diagram-disappearing fix).
